### PR TITLE
feat(auth): implement logout flow and session termination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added reset-password presentation flow: `ResetPasswordCubit`, `ResetPasswordPageBuilder`, and `ResetPasswordPage` integrated with router.
 - Added new auth route path for the final password recovery step: `/auth/forgot-password/reset`.
 - Added unit tests for `AuthRepositoryImpl.resetPassword` and `ResetPasswordCubit`.
+- Added logout API contract and DTOs in auth data layer (`LogoutResponseDto`) and wired `AuthApiClient.logout`.
+- Added auth domain/data logout flow: `AuthRepository.logout` contract and `AuthRepositoryImpl` implementation.
+- Added logout presentation flow: `LogoutCubit` and logout action wiring on the debug screen.
+- Added unit tests for `AuthRepositoryImpl.logout`, `LogoutCubit`, and updated `AuthSessionCubit.logout`.
 
 ### Changed
 
@@ -90,6 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated verify-reset-code page to reuse `OtpResendCubit` for resend requests, cooldown timer, and success/error snackbar handling.
 - Updated password recovery flow to finish with `go(signInPath)` after successful password reset.
 - Updated sign-in forgot-password action to route to the dedicated password recovery request screen.
+- Updated `AuthSessionCubit.logout` to finish only the local session state; backend logout is now handled through the dedicated logout flow before session transition.
 
 ### Fixed
 

--- a/lib/features/auth/data/dto/logout_response_dto.dart
+++ b/lib/features/auth/data/dto/logout_response_dto.dart
@@ -1,0 +1,23 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'logout_response_dto.g.dart';
+
+/// DTO for logout response.
+@JsonSerializable(createToJson: false)
+class LogoutResponseDto {
+  /// Indicates whether logout succeeded.
+  final bool success;
+
+  /// Backend message about logout result.
+  final String message;
+
+  /// Creates an instance of [LogoutResponseDto].
+  LogoutResponseDto({
+    required this.success,
+    required this.message,
+  });
+
+  /// Creates a [LogoutResponseDto] from JSON.
+  factory LogoutResponseDto.fromJson(Map<String, dynamic> json) =>
+      _$LogoutResponseDtoFromJson(json);
+}

--- a/lib/features/auth/data/remote/auth_api_client.dart
+++ b/lib/features/auth/data/remote/auth_api_client.dart
@@ -5,6 +5,7 @@ import '../dto/forgot_password_request_dto.dart';
 import '../dto/forgot_password_response_dto.dart';
 import '../dto/login_request_dto.dart';
 import '../dto/login_response_dto.dart';
+import '../dto/logout_response_dto.dart';
 import '../dto/me_response_dto.dart';
 import '../dto/register_request_dto.dart';
 import '../dto/register_response_dto.dart';
@@ -32,6 +33,10 @@ abstract class AuthApiClient {
   /// Sends register request and returns registered user payload.
   @POST('/register')
   Future<RegisterResponseDto> register(@Body() RegisterRequestDto request);
+
+  /// Sends logout request and returns backend message.
+  @POST('/logout')
+  Future<LogoutResponseDto> logout();
 
   /// Sends forgot password request and returns backend message.
   @POST('/forgot-password')

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -33,6 +33,25 @@ final class AuthRepositoryImpl implements AuthRepository {
   AuthRepositoryImpl(this._logger, this._apiClient, this._tokenStorage);
 
   @override
+  Future<Result<void, AuthFailure>> logout() async {
+    try {
+      await _apiClient.logout();
+      await _tokenStorage.deleteAccessToken();
+      return const Result.success(null);
+    } on DioException catch (e) {
+      final networkFailure = e.toNetworkFailure();
+      final failure = networkFailure.toAuthFailure();
+      if (failure is UnauthorizedAuthFailure) {
+        await _tokenStorage.deleteAccessToken();
+      }
+      return Result.failure(failure);
+    } catch (e, s) {
+      _logger.e('Logout failed with unexpected error', e, s);
+      return Result.failure(UnknownAuthFailure(parentException: e, stackTrace: s));
+    }
+  }
+
+  @override
   Future<Result<User, AuthFailure>> signIn(String email, String password) async {
     try {
       final request = LoginRequestDto(email: email, password: password);

--- a/lib/features/auth/domain/repositories/auth_repository.dart
+++ b/lib/features/auth/domain/repositories/auth_repository.dart
@@ -10,6 +10,9 @@ abstract interface class AuthRepository {
   /// Signs up a user with name, email and password.
   Future<Result<User, AuthFailure>> signUp(String name, String email, String password);
 
+  /// Logs out the current user.
+  Future<Result<void, AuthFailure>> logout();
+
   /// Requests password reset OTP for the given email.
   Future<Result<void, AuthFailure>> forgotPassword(String email);
 

--- a/lib/features/auth/presentation/cubits/auth_session_cubit.dart
+++ b/lib/features/auth/presentation/cubits/auth_session_cubit.dart
@@ -70,13 +70,8 @@ final class AuthSessionCubit extends Cubit<AuthSessionState> {
 
   /// Clears session and emits unauthenticated state.
   Future<void> logout() async {
-    // TODO(feature/auth-logout): call backend /logout before local token cleanup.
-    try {
-      await _tokenStorage.deleteAccessToken();
-    } finally {
-      if (!isClosed) {
-        emit(const AuthSessionState.unauthenticated());
-      }
+    if (!isClosed) {
+      emit(const AuthSessionState.unauthenticated());
     }
   }
 }

--- a/lib/features/auth/presentation/cubits/logout_cubit.dart
+++ b/lib/features/auth/presentation/cubits/logout_cubit.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../../../core/failures/feature/auth/auth_failure.dart';
+import '../../../../core/result/result.dart';
+import '../../domain/repositories/auth_repository.dart';
+
+part 'logout_cubit.freezed.dart';
+part 'logout_state.dart';
+
+/// Cubit that manages logout flow and emits [LogoutState].
+final class LogoutCubit extends Cubit<LogoutState> {
+  /// Authentication repository used for logout requests.
+  final AuthRepository _repository;
+
+  /// Creates an instance of [LogoutCubit].
+  LogoutCubit(this._repository) : super(const LogoutState.initial());
+
+  /// Attempts to logout the current user.
+  Future<void> logout() async {
+    if (state is _InProgress) return;
+
+    emit(const LogoutState.inProgress());
+
+    final result = await _repository.logout();
+    if (isClosed) return;
+
+    switch (result) {
+      case Success():
+        emit(const LogoutState.succeed());
+      case Failure(:final error):
+        if (error is UnauthorizedAuthFailure) {
+          emit(const LogoutState.succeed());
+          return;
+        }
+        emit(LogoutState.failed(error));
+    }
+  }
+}

--- a/lib/features/auth/presentation/cubits/logout_state.dart
+++ b/lib/features/auth/presentation/cubits/logout_state.dart
@@ -1,0 +1,17 @@
+part of 'logout_cubit.dart';
+
+/// States for [LogoutCubit].
+@freezed
+class LogoutState with _$LogoutState {
+  /// Initial idle state before any logout attempt.
+  const factory LogoutState.initial() = _Initial;
+
+  /// State emitted when logout succeeds.
+  const factory LogoutState.succeed() = _Succeed;
+
+  /// State emitted when logout fails.
+  const factory LogoutState.failed(AuthFailure failure) = _Failed;
+
+  /// State emitted while logout request is in progress.
+  const factory LogoutState.inProgress() = _InProgress;
+}

--- a/lib/features/debug/presentation/debug_screen.dart
+++ b/lib/features/debug/presentation/debug_screen.dart
@@ -15,7 +15,7 @@ class DebugScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return MultiBlocProvider(
       providers: [
-        BlocProvider(create: (context) => di<AuthSessionCubit>()),
+        BlocProvider.value(value: di<AuthSessionCubit>()),
         BlocProvider(
           create: (context) => LogoutCubit(di<AuthRepository>()),
         ),

--- a/lib/features/debug/presentation/debug_screen.dart
+++ b/lib/features/debug/presentation/debug_screen.dart
@@ -1,4 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../core/di/di.dart';
+import '../../auth/domain/repositories/auth_repository.dart';
+import '../../auth/presentation/cubits/auth_session_cubit.dart';
+import '../../auth/presentation/cubits/logout_cubit.dart';
 
 /// A screen for debugging purposes.
 class DebugScreen extends StatelessWidget {
@@ -7,9 +13,49 @@ class DebugScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(
-        child: Text('Debug Screen'),
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider(create: (context) => di<AuthSessionCubit>()),
+        BlocProvider(
+          create: (context) => LogoutCubit(di<AuthRepository>()),
+        ),
+      ],
+      child: BlocListener<LogoutCubit, LogoutState>(
+        listener: (context, state) {
+          state.whenOrNull(
+            succeed: () => context.read<AuthSessionCubit>().logout(),
+            failed: (failure) {
+              if (failure.message.isNotEmpty) {
+                final messenger = ScaffoldMessenger.of(context);
+                messenger
+                  ..hideCurrentSnackBar()
+                  ..showSnackBar(SnackBar(content: Text(failure.message)));
+              }
+            },
+          );
+        },
+        child: Scaffold(
+          body: Center(
+            child: BlocBuilder<LogoutCubit, LogoutState>(
+              builder: (context, state) {
+                final isInProgress = state.maybeWhen(
+                  inProgress: () => true,
+                  orElse: () => false,
+                );
+                return FilledButton(
+                  onPressed: isInProgress ? null : () => context.read<LogoutCubit>().logout(),
+                  child: isInProgress
+                      ? const SizedBox(
+                          height: 20,
+                          width: 20,
+                          child: CircularProgressIndicator.adaptive(),
+                        )
+                      : const Text('Выйти'),
+                );
+              },
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/test/features/auth/data/repositories/auth_repository_impl_logout_test.dart
+++ b/test/features/auth/data/repositories/auth_repository_impl_logout_test.dart
@@ -1,0 +1,107 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:moveup_flutter/core/failures/feature/auth/auth_failure.dart';
+import 'package:moveup_flutter/core/services/token_storage/token_storage.dart';
+import 'package:moveup_flutter/core/utils/logger/app_logger.dart';
+import 'package:moveup_flutter/features/auth/data/dto/logout_response_dto.dart';
+import 'package:moveup_flutter/features/auth/data/remote/auth_api_client.dart';
+import 'package:moveup_flutter/features/auth/data/repositories/auth_repository_impl.dart';
+import 'package:moveup_flutter/features/auth/domain/repositories/auth_repository.dart';
+
+import '../../support/auth_dto_fixtures.dart';
+import 'auth_repository_impl_logout_test.mocks.dart';
+
+@GenerateNiceMocks([
+  MockSpec<AppLogger>(),
+  MockSpec<AuthApiClient>(),
+  MockSpec<TokenStorage>(),
+])
+void main() {
+  late MockAppLogger logger;
+  late MockAuthApiClient apiClient;
+  late MockTokenStorage tokenStorage;
+  late AuthRepository repository;
+
+  setUp(() {
+    logger = MockAppLogger();
+    apiClient = MockAuthApiClient();
+    tokenStorage = MockTokenStorage();
+    repository = AuthRepositoryImpl(logger, apiClient, tokenStorage);
+  });
+
+  group('AuthRepositoryImpl.logout', () {
+    late LogoutResponseDto logoutResponseDto;
+
+    setUp(() {
+      logoutResponseDto = LogoutResponseDto(
+        success: true,
+        message: 'success_message',
+      );
+    });
+
+    test('returns success and deletes token when api logout succeeds', () async {
+      // Arrange
+      when(apiClient.logout()).thenAnswer((_) async => logoutResponseDto);
+      when(tokenStorage.deleteAccessToken()).thenAnswer((_) async {});
+
+      // Act
+      final result = await repository.logout();
+
+      // Assert
+      expect(result.isSuccess, isTrue);
+
+      verify(apiClient.logout()).called(1);
+      verifyNoMoreInteractions(apiClient);
+      verify(tokenStorage.deleteAccessToken()).called(1);
+      verifyNoMoreInteractions(tokenStorage);
+    });
+
+    test('returns UnauthorizedAuthFailure and deletes token when api returns 401 unauthorized', () async {
+      // Arrange
+      final exception = createDioBadResponseException(
+        path: '/logout',
+        statusCode: 401,
+        code: 'unauthorized',
+      );
+      when(apiClient.logout()).thenThrow(exception);
+      when(tokenStorage.deleteAccessToken()).thenAnswer((_) async {});
+
+      // Act
+      final result = await repository.logout();
+
+      // Assert
+      expect(result.isFailure, isTrue);
+
+      final failure = result.failure!;
+      expect(failure, isA<UnauthorizedAuthFailure>());
+      expect(failure.parentException, isA<DioException>());
+
+      verify(apiClient.logout()).called(1);
+      verifyNoMoreInteractions(apiClient);
+      verify(tokenStorage.deleteAccessToken()).called(1);
+      verifyNoMoreInteractions(tokenStorage);
+    });
+
+    test('returns UnknownAuthFailure when unexpected exception occurs', () async {
+      // Arrange
+      final unknownException = Exception('unexpected_error');
+      when(apiClient.logout()).thenThrow(unknownException);
+
+      // Act
+      final result = await repository.logout();
+
+      // Assert
+      expect(result.isFailure, isTrue);
+
+      final failure = result.failure!;
+      expect(failure, isA<UnknownAuthFailure>());
+      expect(failure.parentException, unknownException);
+
+      verify(apiClient.logout()).called(1);
+      verifyNoMoreInteractions(apiClient);
+      verifyNoMoreInteractions(tokenStorage);
+    });
+  });
+}

--- a/test/features/auth/presentation/cubits/auth_session_cubit_test.dart
+++ b/test/features/auth/presentation/cubits/auth_session_cubit_test.dart
@@ -127,14 +127,14 @@ void main() {
     );
 
     blocTest<AuthSessionCubit, AuthSessionState>(
-      'logout deletes token and emits unauthenticated',
-      setUp: () {
-        when(tokenStorage.deleteAccessToken()).thenAnswer((_) async {});
-      },
+      'logout emits unauthenticated without touching token storage directly',
       build: () => authSessionCubit,
       act: (cubit) => cubit.logout(),
       expect: () => const [AuthSessionState.unauthenticated()],
-      verify: (_) => verify(tokenStorage.deleteAccessToken()).called(1),
+      verify: (_) {
+        verifyNoMoreInteractions(repository);
+        verifyNoMoreInteractions(tokenStorage);
+      },
     );
 
     blocTest<AuthSessionCubit, AuthSessionState>(

--- a/test/features/auth/presentation/cubits/logout_cubit_test.dart
+++ b/test/features/auth/presentation/cubits/logout_cubit_test.dart
@@ -1,0 +1,85 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:moveup_flutter/core/failures/feature/auth/auth_failure.dart';
+import 'package:moveup_flutter/core/result/result.dart';
+import 'package:moveup_flutter/features/auth/domain/repositories/auth_repository.dart';
+import 'package:moveup_flutter/features/auth/presentation/cubits/logout_cubit.dart';
+
+import 'logout_cubit_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<AuthRepository>()])
+void main() {
+  late MockAuthRepository repository;
+  late LogoutCubit logoutCubit;
+
+  setUp(() {
+    repository = MockAuthRepository();
+    logoutCubit = LogoutCubit(repository);
+    provideDummy<Result<void, AuthFailure>>(const Success<void, AuthFailure>(null));
+  });
+
+  group('LogoutCubit', () {
+    const authFailure = UnknownAuthFailure();
+
+    blocTest<LogoutCubit, LogoutState>(
+      'emits inProgress only once when logout is called twice',
+      setUp: () => when(repository.logout()).thenAnswer(
+        (_) async => const Success<void, AuthFailure>(null),
+      ),
+      build: () => logoutCubit,
+      act: (cubit) {
+        cubit.logout();
+        cubit.logout();
+      },
+      expect: () => const [
+        LogoutState.inProgress(),
+        LogoutState.succeed(),
+      ],
+      verify: (_) => verify(repository.logout()).called(1),
+    );
+
+    blocTest<LogoutCubit, LogoutState>(
+      'emits succeed when logout succeeds',
+      setUp: () => when(repository.logout()).thenAnswer(
+        (_) async => const Success<void, AuthFailure>(null),
+      ),
+      build: () => logoutCubit,
+      act: (cubit) => cubit.logout(),
+      expect: () => const [
+        LogoutState.inProgress(),
+        LogoutState.succeed(),
+      ],
+      verify: (_) => verify(repository.logout()).called(1),
+    );
+
+    blocTest<LogoutCubit, LogoutState>(
+      'emits succeed when logout fails with UnauthorizedAuthFailure',
+      setUp: () => when(repository.logout()).thenAnswer(
+        (_) async => const Failure(UnauthorizedAuthFailure()),
+      ),
+      build: () => logoutCubit,
+      act: (cubit) => cubit.logout(),
+      expect: () => const [
+        LogoutState.inProgress(),
+        LogoutState.succeed(),
+      ],
+      verify: (_) => verify(repository.logout()).called(1),
+    );
+
+    blocTest<LogoutCubit, LogoutState>(
+      'emits failed(authFailure) when logout fails with non-unauthorized failure',
+      setUp: () => when(repository.logout()).thenAnswer(
+        (_) async => const Failure(authFailure),
+      ),
+      build: () => logoutCubit,
+      act: (cubit) => cubit.logout(),
+      expect: () => const [
+        LogoutState.inProgress(),
+        LogoutState.failed(authFailure),
+      ],
+      verify: (_) => verify(repository.logout()).called(1),
+    );
+  });
+}


### PR DESCRIPTION
## 🚀 Summary

Implemented the `/logout` vertical slice end-to-end (API client → repository → cubit → UI → session), adding backend-backed logout handling and wiring session termination through the existing auth redirect flow.

## ✨ Changes

- ✅ Added `/logout` integration: `LogoutResponseDto`, `AuthApiClient.logout`
- ✅ Added auth domain/data logout flow: `AuthRepository.logout` and `AuthRepositoryImpl.logout` + unit tests
- ✅ Added `LogoutCubit` + unit tests
- ✅ Updated `AuthSessionCubit.logout` to finish only the local session state after the dedicated logout flow completes
- ✅ Added minimal logout UI to `DebugScreen`
- ✅ Wired `DebugScreen` logout action through `LogoutCubit` and `AuthSessionCubit`
- ✅ Kept `401 unauthorized` logout handling idempotent on the client: token is cleared and session can still be ended 

## 🧪 Verification

- [x] `flutter pub run build_runner build --delete-conflicting-outputs`
- [x] `flutter analyze`
- [x] `flutter test test/features/auth`
