### PR TITLE
feat(fitness-start): add final weekly goal onboarding step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `FitnessStartProgressStorage` with `Hive`-based persistence for completed guest onboarding resume after app restart.
 - Persistent guest session cookie storage and cleanup wiring for backend-backed onboarding resume.
 - `FitnessStartApiClient`, DTOs, repository contract/implementation, and dedicated `FitnessStartFailure` mapping for `user-parameters` endpoints.
+- `PhasesApiClient`, `PhasesRepository`, `PhasesFailure` mapping, and `WeeklyGoalCubit` for the final weekly-goal onboarding step.
 - Shared `tests catalog` slice for `GET /api/testings`, including `TestsApiClient`, DTOs, failure mapping, repository, Cubit, and onboarding carousel widgets.
 - Shared guest `tests attempt` slice for `/api/guest/tests/{testing}/start`, `/api/guest/test-attempts/{attempt}/result`, and `/api/guest/test-attempts/{attempt}/complete`, including DTOs, repository, Cubit, validators, and onboarding attempt UI.
 - Shared UIKit controls for the onboarding quiz: `AppCard`, `OptionButton`, and `AppInputField`.
 - Shared UIKit `SecondaryButton` and `AppActionDialog` for onboarding/auth action modals.
 - `FitnessStartCubit`, validators, 3-step quiz UI, `/fitness-start/tests` onboarding shell screen, and sign-in resume dialog for the onboarding-first auth entry flow.
+- `/fitness-start/weekly-goal` final guest onboarding screen for adjusting weekly training goal before handoff to registration.
 
 ### Changed
 
@@ -29,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Verify-email success now completes authentication directly instead of entering a staged authenticated onboarding flow.
 - Dio clients now attach a shared persistent `CookieManager` so guest onboarding progress and backend session can survive app restarts.
 - `/fitness-start/tests` now shows the onboarding tests catalog carousel instead of the previous placeholder CTA, remains part of the `fitness_start` shell flow, and its back action exits guest flow to `sign-in`.
-- Selecting a testing in the onboarding catalog now pushes a guest test attempt route, saves per-exercise results through guest endpoints, collects pulse after the last exercise, and completes guest onboarding before redirecting to `sign-up`.
+- Selecting a testing in the onboarding catalog now pushes a guest test attempt route, saves per-exercise results through guest endpoints, collects pulse after the last exercise, and advances to a final weekly-goal step before completing guest onboarding and redirecting to `sign-up`.
 - `Fitness Start` validation feedback now removes duplicate backend field messages before showing them to the user.
 - `Fitness Start` quiz selections are now locked while a submit request is in progress.
 - `Fitness Start` quiz now keeps initial references loading and retry states inline in the card instead of collapsing to a blank screen.

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -154,6 +154,17 @@ abstract final class AppStrings {
   static const fitnessStartTestsTitle = 'Персональная программа';
   static const fitnessStartTestsDescription =
       'Всего несколько быстрых тестов помогут подобрать безопасные и эффективные упражнения для Вашего уровня подготовки';
+  static const fitnessStartWeeklyGoalHeading = 'Программа тренировок составлена';
+  static const fitnessStartWeeklyGoalSubtitle =
+      'С учетом заполненной информации и тестирования рекомендуется заниматься 4 раза в неделю';
+  static const fitnessStartWeeklyGoalPrompt = 'Введите пранируемое количество тренировок в неделю';
+  static const fitnessStartWeeklyGoalDescription =
+      'Вы можете указать такое же количество, либо другое, после чего программа тренировок сгенерируется заново';
+  static const fitnessStartWeeklyGoalHint = 'Введите количество тренировок';
+  static const fitnessStartWeeklyGoalButton = 'Приступить';
+  static const fitnessStartWeeklyGoalRequired = 'Введите количество тренировок';
+  static const fitnessStartWeeklyGoalInvalid = 'Введите корректное количество тренировок';
+  static const fitnessStartWeeklyGoalRange = 'Количество тренировок должно быть от 1 до 7';
 
   // Tests catalog.
   static const testsMinutesPattern = 'минут';
@@ -173,6 +184,10 @@ abstract final class AppStrings {
   static const testsAttemptResultPoor = 'Плохо';
   static const testsAttemptResultNormal = 'Нормально';
   static const testsAttemptResultGood = 'Хорошо';
+
+  /// Phases failures.
+  static const phasesValidationFailed = 'Проверьте введенные данные и попробуйте снова';
+  static const phasesUnknown = 'Не удалось выполнить действие. Попробуйте снова';
 
   /// Debug screen.
   static const debugLogoutButton = 'Выйти';

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -157,7 +157,7 @@ abstract final class AppStrings {
   static const fitnessStartWeeklyGoalHeading = 'Программа тренировок составлена';
   static const fitnessStartWeeklyGoalSubtitle =
       'С учетом заполненной информации и тестирования рекомендуется заниматься 4 раза в неделю';
-  static const fitnessStartWeeklyGoalPrompt = 'Введите пранируемое количество тренировок в неделю';
+  static const fitnessStartWeeklyGoalPrompt = 'Введите планируемое количество тренировок в неделю';
   static const fitnessStartWeeklyGoalDescription =
       'Вы можете указать такое же количество, либо другое, после чего программа тренировок сгенерируется заново';
   static const fitnessStartWeeklyGoalHint = 'Введите количество тренировок';

--- a/lib/core/di/di.dart
+++ b/lib/core/di/di.dart
@@ -16,11 +16,14 @@ import '../../features/auth/presentation/cubits/auth_session_cubit.dart';
 import '../../features/fitness_start/data/remote/fitness_start_api_client.dart';
 import '../../features/fitness_start/data/repositories/fitness_start_repository_impl.dart';
 import '../../features/fitness_start/domain/repositories/fitness_start_repository.dart';
-import '../../features/tests/data/remote/tests_api_client.dart';
-import '../../features/tests/catalog/data/repositories/tests_catalog_repository_impl.dart';
-import '../../features/tests/catalog/domain/repositories/tests_catalog_repository.dart';
+import '../../features/phases/data/remote/phases_api_client.dart';
+import '../../features/phases/data/repositories/phases_repository_impl.dart';
+import '../../features/phases/domain/repositories/phases_repository.dart';
 import '../../features/tests/attempt/data/repositories/guest_test_attempt_repository_impl.dart';
 import '../../features/tests/attempt/domain/repositories/test_attempt_repository.dart';
+import '../../features/tests/catalog/data/repositories/tests_catalog_repository_impl.dart';
+import '../../features/tests/catalog/domain/repositories/tests_catalog_repository.dart';
+import '../../features/tests/data/remote/tests_api_client.dart';
 import '../network/api_paths.dart';
 import '../network/dio_setup.dart';
 import '../services/fitness_start_progress_storage/fitness_start_progress_storage.dart';
@@ -131,6 +134,15 @@ Future<void> setupDI() async {
     () => GuestTestAttemptRepositoryImpl(
       di<AppLogger>(),
       di<TestsApiClient>(),
+    ),
+  );
+
+  // Phases
+  di.registerLazySingleton<PhasesApiClient>(() => PhasesApiClient(di<Dio>()));
+  di.registerLazySingleton<PhasesRepository>(
+    () => PhasesRepositoryImpl(
+      di<AppLogger>(),
+      di<PhasesApiClient>(),
     ),
   );
 }

--- a/lib/core/failures/feature/phases/phases_failure.dart
+++ b/lib/core/failures/feature/phases/phases_failure.dart
@@ -1,0 +1,41 @@
+import '../../../constants/app_strings.dart';
+import '../../app_failure.dart';
+
+/// Phases application error.
+sealed class PhasesFailure extends AppFailure {
+  /// Creates an instance of [PhasesFailure].
+  const PhasesFailure(
+    super.message, {
+    super.parentException,
+    super.stackTrace,
+  });
+}
+
+/// Phases request failed because of infrastructure or network conditions.
+final class PhasesRequestFailure extends PhasesFailure {
+  /// Creates an instance of [PhasesRequestFailure].
+  const PhasesRequestFailure(
+    super.message, {
+    super.parentException,
+    super.stackTrace,
+  });
+}
+
+/// Phases validation failed because the provided input is invalid.
+final class PhasesValidationFailure extends PhasesFailure {
+  /// Creates an instance of [PhasesValidationFailure].
+  const PhasesValidationFailure({
+    String message = AppStrings.phasesValidationFailed,
+    super.parentException,
+    super.stackTrace,
+  }) : super(message);
+}
+
+/// Unknown phases failure.
+final class UnknownPhasesFailure extends PhasesFailure {
+  /// Creates an instance of [UnknownPhasesFailure].
+  const UnknownPhasesFailure({
+    super.parentException,
+    super.stackTrace,
+  }) : super(AppStrings.phasesUnknown);
+}

--- a/lib/core/network/api_paths.dart
+++ b/lib/core/network/api_paths.dart
@@ -61,4 +61,7 @@ abstract class ApiPaths {
 
   /// The endpoint prefix for guest test attempts.
   static const String guestTestAttempts = '${apiPrefix}guest/test-attempts';
+
+  /// The endpoint for updating user weekly training goal.
+  static const String userWeeklyGoal = '${apiPrefix}user/weekly-goal';
 }

--- a/lib/core/router/router.dart
+++ b/lib/core/router/router.dart
@@ -17,6 +17,7 @@ import '../../features/debug/presentation/debug_screen.dart';
 import '../../features/fitness_start/presentation/pages/fitness_start_quiz_page_builder.dart';
 import '../../features/fitness_start/presentation/pages/fitness_start_test_attempt_page_builder.dart';
 import '../../features/fitness_start/presentation/pages/fitness_start_tests_page_builder.dart';
+import '../../features/fitness_start/presentation/pages/fitness_start_weekly_goal_page_builder.dart';
 import '../di/di.dart';
 import '../utils/analytics/app_analytics.dart';
 import 'analytics_route_observer.dart';
@@ -190,6 +191,16 @@ final router = GoRouter(
       builder: (_, state) => FitnessStartTestAttemptPageBuilder(
         testingId: int.parse(state.pathParameters['testingId']!),
       ),
+    ),
+    GoRoute(
+      path: AppRoutePaths.fitnessStartWeeklyGoalPath,
+      redirect: (_, state) {
+        if (state.extra == AppRoutePaths.fitnessStartTestAttemptBasePath) {
+          return null;
+        }
+        return AppRoutePaths.fitnessStartTestsPath;
+      },
+      builder: (_, _) => const FitnessStartWeeklyGoalPageBuilder(),
     ),
   ],
 );

--- a/lib/core/router/router_paths.dart
+++ b/lib/core/router/router_paths.dart
@@ -42,6 +42,9 @@ abstract class AppRoutePaths {
   /// Route path pattern for a concrete test attempt inside Fitness Start.
   static const fitnessStartTestAttemptPath = '$fitnessStartTestAttemptBasePath/:testingId';
 
+  /// Route path for the final weekly-goal onboarding step.
+  static const fitnessStartWeeklyGoalPath = '$fitnessStartPrefix/weekly-goal';
+
   /// Builds the concrete route path for a test attempt by [testingId].
   static String fitnessStartTestAttemptDetailsPath(int testingId) =>
       '$fitnessStartTestAttemptBasePath/$testingId';

--- a/lib/features/fitness_start/presentation/pages/fitness_start_test_attempt_page.dart
+++ b/lib/features/fitness_start/presentation/pages/fitness_start_test_attempt_page.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../core/constants/app_assets.dart';
 import '../../../../core/constants/app_strings.dart';
+import '../../../../core/router/router_paths.dart';
 import '../../../../uikit/buttons/button_state.dart';
 import '../../../../uikit/buttons/main_button.dart';
 import '../../../../uikit/buttons/option_button.dart';
@@ -16,7 +17,6 @@ import '../../../../uikit/images/network_image_widget.dart';
 import '../../../../uikit/images/svg_picture_widget.dart';
 import '../../../../uikit/themes/colors/app_color_theme.dart';
 import '../../../../uikit/themes/text/app_text_theme.dart';
-import '../../../auth/presentation/cubits/auth_session_cubit.dart';
 import '../../../tests/attempt/presentation/cubits/test_attempt_cubit.dart';
 import '../widgets/fitness_start_flow_app_bar.dart';
 
@@ -89,7 +89,10 @@ class _FitnessStartTestAttemptPageState extends State<FitnessStartTestAttemptPag
           _cubit.clearFailure();
         }
         if (state.isCompleted) {
-          unawaited(context.read<AuthSessionCubit>().completeGuestFitnessStart());
+          context.go(
+            AppRoutePaths.fitnessStartWeeklyGoalPath,
+            extra: AppRoutePaths.fitnessStartTestAttemptBasePath,
+          );
         }
       },
       builder: (context, state) {

--- a/lib/features/fitness_start/presentation/pages/fitness_start_weekly_goal_page.dart
+++ b/lib/features/fitness_start/presentation/pages/fitness_start_weekly_goal_page.dart
@@ -1,0 +1,208 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../core/constants/app_assets.dart';
+import '../../../../core/constants/app_strings.dart';
+import '../../../../uikit/buttons/button_state.dart';
+import '../../../../uikit/buttons/main_button.dart';
+import '../../../../uikit/dialogs/app_feedback_dialog.dart';
+import '../../../../uikit/images/svg_picture_widget.dart';
+import '../../../../uikit/themes/colors/app_color_theme.dart';
+import '../../../../uikit/themes/text/app_text_theme.dart';
+import '../../../auth/presentation/cubits/auth_session_cubit.dart';
+import '../../../phases/presentation/cubits/weekly_goal_cubit.dart';
+import '../widgets/fitness_start_flow_app_bar.dart';
+
+/// Final guest onboarding page for editing weekly training goal.
+class FitnessStartWeeklyGoalPage extends StatefulWidget {
+  /// Creates an instance of [FitnessStartWeeklyGoalPage].
+  const FitnessStartWeeklyGoalPage({super.key});
+
+  @override
+  State<FitnessStartWeeklyGoalPage> createState() => _FitnessStartWeeklyGoalPageState();
+}
+
+class _FitnessStartWeeklyGoalPageState extends State<FitnessStartWeeklyGoalPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _weeklyGoalController = TextEditingController();
+
+  @override
+  void dispose() {
+    _weeklyGoalController.dispose();
+    super.dispose();
+  }
+
+  String? _validateWeeklyGoal(String? value) {
+    final trimmedValue = value?.trim() ?? '';
+    if (trimmedValue.isEmpty) return AppStrings.fitnessStartWeeklyGoalRequired;
+
+    final weeklyGoal = int.tryParse(trimmedValue);
+    if (weeklyGoal == null) return AppStrings.fitnessStartWeeklyGoalInvalid;
+    if (weeklyGoal < 1 || weeklyGoal > 7) return AppStrings.fitnessStartWeeklyGoalRange;
+
+    return null;
+  }
+
+  Future<void> _submit() async {
+    FocusScope.of(context).unfocus();
+    final trimmedValue = _weeklyGoalController.text.trim();
+    // empty input means the user keeps the recommended default goal (4),
+    // so we skip a redundant update request and finish onboarding immediately.
+    if (trimmedValue.isEmpty) {
+      await context.read<AuthSessionCubit>().completeGuestFitnessStart();
+      return;
+    }
+
+    final form = _formKey.currentState;
+    if (form == null || !form.validate()) return;
+
+    await context.read<WeeklyGoalCubit>().updateWeeklyGoal(int.parse(trimmedValue));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorTheme = AppColorTheme.of(context);
+    return BlocConsumer<WeeklyGoalCubit, WeeklyGoalState>(
+      listener: (context, state) {
+        state.whenOrNull(
+          succeed: () {
+            unawaited(context.read<AuthSessionCubit>().completeGuestFitnessStart());
+          },
+          failed: (failure) {
+            showAppFeedbackDialog(
+              context,
+              title: AppStrings.feedbackErrorTitle,
+              message: failure.message,
+            );
+          },
+        );
+      },
+      builder: (context, state) {
+        final isInProgress = state.maybeWhen(
+          inProgress: () => true,
+          orElse: () => false,
+        );
+        return Scaffold(
+          appBar: FitnessStartFlowAppBar(
+            progress: 1.0,
+            showBackButton: true,
+            onBackPressed: () => unawaited(context.read<AuthSessionCubit>().cancelGuestFlow()),
+          ),
+          body: Stack(
+            children: [
+              Positioned(
+                left: -140,
+                top: 10,
+                child: IgnorePointer(
+                  child: ExcludeSemantics(
+                    child: Transform.rotate(
+                      angle: -200 * (math.pi / 180),
+                      child: Transform.scale(
+                        scaleY: -1,
+                        child: SvgPictureWidget.frame(
+                          AppAssets.imageFigure,
+                          color: colorTheme.primary.withValues(alpha: 0.3),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              Positioned(
+                right: -85,
+                bottom: -110,
+                child: IgnorePointer(
+                  child: ExcludeSemantics(
+                    child: SvgPictureWidget.frame(
+                      AppAssets.imageFigure,
+                      color: colorTheme.secondary.withValues(alpha: 0.3),
+                    ),
+                  ),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(24, 12, 24, 64),
+                child: Form(
+                  key: _formKey,
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Expanded(
+                        child: SingleChildScrollView(
+                          child: _buildContent(context, isInProgress),
+                        ),
+                      ),
+                      const SizedBox(height: 24),
+                      MainButton(
+                        state: isInProgress ? ButtonState.loading : ButtonState.enabled,
+                        onPressed: _submit,
+                        child: const Text(AppStrings.fitnessStartWeeklyGoalButton),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildContent(BuildContext context, bool isInProgress) {
+    final textTheme = AppTextTheme.of(context);
+    final colorTheme = AppColorTheme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          AppStrings.fitnessStartWeeklyGoalHeading,
+          textAlign: TextAlign.center,
+          style: textTheme.title.copyWith(
+            fontSize: 20,
+            height: 24 / 20,
+            color: colorTheme.onSurface,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Text(
+          AppStrings.fitnessStartWeeklyGoalSubtitle,
+          textAlign: TextAlign.center,
+          style: textTheme.bodyMedium.copyWith(
+            fontWeight: FontWeight.w500,
+            color: colorTheme.hint,
+          ),
+        ),
+        const SizedBox(height: 64),
+        Text(
+          AppStrings.fitnessStartWeeklyGoalPrompt,
+          textAlign: TextAlign.center,
+          style: textTheme.bodyMedium.copyWith(color: colorTheme.onSurface),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          AppStrings.fitnessStartWeeklyGoalDescription,
+          textAlign: TextAlign.center,
+          style: textTheme.bodyMedium.copyWith(color: colorTheme.onSurface),
+        ),
+        const SizedBox(height: 16),
+        TextFormField(
+          controller: _weeklyGoalController,
+          enabled: !isInProgress,
+          keyboardType: TextInputType.number,
+          validator: _validateWeeklyGoal,
+          textInputAction: TextInputAction.done,
+          inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+          style: textTheme.body.copyWith(color: colorTheme.onSurface),
+          decoration: const InputDecoration(
+            hintText: AppStrings.fitnessStartWeeklyGoalHint,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/fitness_start/presentation/pages/fitness_start_weekly_goal_page_builder.dart
+++ b/lib/features/fitness_start/presentation/pages/fitness_start_weekly_goal_page_builder.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../core/di/di.dart';
+import '../../../phases/domain/repositories/phases_repository.dart';
+import '../../../phases/presentation/cubits/weekly_goal_cubit.dart';
+import 'fitness_start_weekly_goal_page.dart';
+
+/// Builder for the final Fitness Start weekly-goal page.
+class FitnessStartWeeklyGoalPageBuilder extends StatelessWidget {
+  /// Creates an instance of [FitnessStartWeeklyGoalPageBuilder].
+  const FitnessStartWeeklyGoalPageBuilder({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => WeeklyGoalCubit(di<PhasesRepository>()),
+      child: const FitnessStartWeeklyGoalPage(),
+    );
+  }
+}

--- a/lib/features/fitness_start/presentation/widgets/fitness_start_flow_app_bar.dart
+++ b/lib/features/fitness_start/presentation/widgets/fitness_start_flow_app_bar.dart
@@ -10,7 +10,7 @@ class FitnessStartFlowAppBar extends StatelessWidget implements PreferredSizeWid
   final double progress;
 
   /// Title displayed in the app bar.
-  final String title;
+  final String? title;
 
   /// Whether the back button should be shown.
   final bool showBackButton;
@@ -21,7 +21,7 @@ class FitnessStartFlowAppBar extends StatelessWidget implements PreferredSizeWid
   /// Creates an instance of [FitnessStartFlowAppBar].
   const FitnessStartFlowAppBar({
     required this.progress,
-    required this.title,
+    this.title,
     this.showBackButton = false,
     this.onBackPressed,
     super.key,
@@ -41,7 +41,7 @@ class FitnessStartFlowAppBar extends StatelessWidget implements PreferredSizeWid
       backgroundColor: colorTheme.surface,
       surfaceTintColor: Colors.transparent,
       title: Text(
-        title,
+        title ?? '',
         style: textTheme.title.copyWith(
           fontSize: 20,
           height: 24 / 20,

--- a/lib/features/phases/data/mappers/phases_failure_mapper.dart
+++ b/lib/features/phases/data/mappers/phases_failure_mapper.dart
@@ -1,0 +1,47 @@
+import '../../../../core/failures/feature/phases/phases_failure.dart';
+import '../../../../core/failures/helpers/validation_message_builder.dart';
+import '../../../../core/failures/network/network_failure.dart';
+
+/// Extension to map [NetworkFailure] into [PhasesFailure].
+extension PhasesFailureMapper on NetworkFailure {
+  /// Maps a [NetworkFailure] into a phases-specific failure.
+  PhasesFailure toPhasesFailure() {
+    switch (code) {
+      case 'validation_failed':
+        final fieldErrors = switch (this) {
+          ValidationFailure(:final errors) => errors,
+          _ => const <String, List<String>>{},
+        };
+        final validationMessage = buildValidationMessage(
+          fieldErrors,
+          fallbackMessage: const PhasesValidationFailure().message,
+        );
+        return PhasesValidationFailure(
+          message: validationMessage,
+          parentException: parentException,
+          stackTrace: stackTrace,
+        );
+    }
+
+    return switch (this) {
+      NoNetworkFailure() ||
+      ConnectionTimeoutFailure() ||
+      BadRequestFailure() ||
+      UnauthorizedFailure() ||
+      ForbiddenFailure() ||
+      NotFoundFailure() ||
+      ConflictFailure() ||
+      RateLimitedFailure() ||
+      ServerErrorFailure() ||
+      UnknownNetworkFailure() => PhasesRequestFailure(
+        message,
+        parentException: parentException,
+        stackTrace: stackTrace,
+      ),
+      _ => UnknownPhasesFailure(
+        parentException: parentException,
+        stackTrace: stackTrace,
+      ),
+    };
+  }
+}

--- a/lib/features/phases/data/remote/phases_api_client.dart
+++ b/lib/features/phases/data/remote/phases_api_client.dart
@@ -1,0 +1,17 @@
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../../../../core/network/api_paths.dart';
+
+part 'phases_api_client.g.dart';
+
+/// Retrofit API client for phases requests.
+@RestApi()
+abstract class PhasesApiClient {
+  /// Creates an instance of [PhasesApiClient].
+  factory PhasesApiClient(Dio dio, {String? baseUrl}) = _PhasesApiClient;
+
+  /// Updates weekly training goal for the current onboarding flow.
+  @POST(ApiPaths.userWeeklyGoal)
+  Future<void> updateWeeklyGoal(@Body() Map<String, int> body);
+}

--- a/lib/features/phases/data/repositories/phases_repository_impl.dart
+++ b/lib/features/phases/data/repositories/phases_repository_impl.dart
@@ -1,0 +1,35 @@
+import 'package:dio/dio.dart';
+
+import '../../../../core/failures/feature/phases/phases_failure.dart';
+import '../../../../core/network/mappers/dio_exception_mapper.dart';
+import '../../../../core/result/result.dart';
+import '../../../../core/utils/logger/app_logger.dart';
+import '../../domain/repositories/phases_repository.dart';
+import '../mappers/phases_failure_mapper.dart';
+import '../remote/phases_api_client.dart';
+
+/// Implementation of [PhasesRepository].
+final class PhasesRepositoryImpl implements PhasesRepository {
+  /// Logger for tracking phases operations and errors.
+  final AppLogger _logger;
+
+  /// API client for phases requests.
+  final PhasesApiClient _apiClient;
+
+  /// Creates an instance of [PhasesRepositoryImpl].
+  PhasesRepositoryImpl(this._logger, this._apiClient);
+
+  @override
+  Future<Result<void, PhasesFailure>> updateWeeklyGoal(int weeklyGoal) async {
+    try {
+      await _apiClient.updateWeeklyGoal({'weekly_goal': weeklyGoal});
+      return const Result.success(null);
+    } on DioException catch (e) {
+      final networkFailure = e.toNetworkFailure();
+      return Result.failure(networkFailure.toPhasesFailure());
+    } catch (e, s) {
+      _logger.e('UpdateWeeklyGoal failed with unexpected error', e, s);
+      return Result.failure(UnknownPhasesFailure(parentException: e, stackTrace: s));
+    }
+  }
+}

--- a/lib/features/phases/domain/repositories/phases_repository.dart
+++ b/lib/features/phases/domain/repositories/phases_repository.dart
@@ -1,0 +1,8 @@
+import '../../../../core/failures/feature/phases/phases_failure.dart';
+import '../../../../core/result/result.dart';
+
+/// Repository contract for phases-related operations.
+abstract interface class PhasesRepository {
+  /// Updates weekly training goal to the provided [weeklyGoal].
+  Future<Result<void, PhasesFailure>> updateWeeklyGoal(int weeklyGoal);
+}

--- a/lib/features/phases/presentation/cubits/weekly_goal_cubit.dart
+++ b/lib/features/phases/presentation/cubits/weekly_goal_cubit.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../../../core/failures/feature/phases/phases_failure.dart';
+import '../../../../core/result/result.dart';
+import '../../domain/repositories/phases_repository.dart';
+
+part 'weekly_goal_cubit.freezed.dart';
+part 'weekly_goal_state.dart';
+
+/// Cubit that manages weekly-goal submit flow and emits [WeeklyGoalState].
+final class WeeklyGoalCubit extends Cubit<WeeklyGoalState> {
+  /// Phases repository used for weekly-goal requests.
+  final PhasesRepository _repository;
+
+  /// Creates an instance of [WeeklyGoalCubit].
+  WeeklyGoalCubit(this._repository) : super(const WeeklyGoalState.initial());
+
+  /// Attempts to update weekly goal with [weeklyGoal].
+  Future<void> updateWeeklyGoal(int weeklyGoal) async {
+    final isInProgress = state.maybeWhen(
+      inProgress: () => true,
+      orElse: () => false,
+    );
+    if (isInProgress) return;
+
+    emit(const WeeklyGoalState.inProgress());
+
+    final result = await _repository.updateWeeklyGoal(weeklyGoal);
+    if (isClosed) return;
+
+    switch (result) {
+      case Success():
+        emit(const WeeklyGoalState.succeed());
+      case Failure(:final error):
+        emit(WeeklyGoalState.failed(error));
+    }
+  }
+}

--- a/lib/features/phases/presentation/cubits/weekly_goal_state.dart
+++ b/lib/features/phases/presentation/cubits/weekly_goal_state.dart
@@ -1,0 +1,17 @@
+part of 'weekly_goal_cubit.dart';
+
+/// States for [WeeklyGoalCubit].
+@freezed
+class WeeklyGoalState with _$WeeklyGoalState {
+  /// Initial idle state before weekly-goal submit.
+  const factory WeeklyGoalState.initial() = _Initial;
+
+  /// State emitted while weekly-goal submit is in progress.
+  const factory WeeklyGoalState.inProgress() = _InProgress;
+
+  /// State emitted when weekly-goal submit succeeds.
+  const factory WeeklyGoalState.succeed() = _Succeed;
+
+  /// State emitted when weekly-goal submit fails.
+  const factory WeeklyGoalState.failed(PhasesFailure failure) = _Failed;
+}

--- a/test/features/phases/data/mappers/phases_failure_mapper_test.dart
+++ b/test/features/phases/data/mappers/phases_failure_mapper_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moveup_flutter/core/constants/app_strings.dart';
+import 'package:moveup_flutter/core/failures/feature/phases/phases_failure.dart';
+import 'package:moveup_flutter/core/failures/network/network_failure.dart';
+import 'package:moveup_flutter/features/phases/data/mappers/phases_failure_mapper.dart';
+
+void main() {
+  group('PhasesFailureMapper.toPhasesFailure', () {
+    test('maps validation_failed to PhasesValidationFailure with validation message', () {
+      const failure = ValidationFailure(
+        errors: {
+          'weekly_goal': ['error_message'],
+        },
+      );
+
+      final result = failure.toPhasesFailure();
+
+      expect(result, isA<PhasesValidationFailure>());
+      expect(result.message, 'error_message');
+    });
+
+    test('falls back to generic phases validation message when field errors are empty', () {
+      final result = const ValidationFailure().toPhasesFailure();
+
+      expect(result, isA<PhasesValidationFailure>());
+      expect(result.message, AppStrings.phasesValidationFailed);
+    });
+
+    test('maps NoNetworkFailure to PhasesRequestFailure', () {
+      final result = const NoNetworkFailure().toPhasesFailure();
+
+      expect(result, isA<PhasesRequestFailure>());
+      expect(result.message, const NoNetworkFailure().message);
+    });
+
+    test('maps ServerErrorFailure to PhasesRequestFailure', () {
+      final result = const ServerErrorFailure().toPhasesFailure();
+
+      expect(result, isA<PhasesRequestFailure>());
+      expect(result.message, const ServerErrorFailure().message);
+    });
+
+    test('maps UnknownNetworkFailure to PhasesRequestFailure', () {
+      final result = const UnknownNetworkFailure().toPhasesFailure();
+
+      expect(result, isA<PhasesRequestFailure>());
+      expect(result.message, const UnknownNetworkFailure().message);
+    });
+  });
+}

--- a/test/features/phases/data/repositories/phases_repository_impl_update_weekly_goal_test.dart
+++ b/test/features/phases/data/repositories/phases_repository_impl_update_weekly_goal_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:moveup_flutter/core/failures/feature/phases/phases_failure.dart';
+import 'package:moveup_flutter/core/utils/logger/app_logger.dart';
+import 'package:moveup_flutter/features/phases/data/remote/phases_api_client.dart';
+import 'package:moveup_flutter/features/phases/data/repositories/phases_repository_impl.dart';
+import 'package:moveup_flutter/features/phases/domain/repositories/phases_repository.dart';
+
+import '../../support/phases_fixtures.dart';
+import 'phases_repository_impl_update_weekly_goal_test.mocks.dart';
+
+@GenerateNiceMocks([
+  MockSpec<AppLogger>(),
+  MockSpec<PhasesApiClient>(),
+])
+void main() {
+  late MockAppLogger logger;
+  late MockPhasesApiClient apiClient;
+  late PhasesRepository repository;
+
+  setUp(() {
+    logger = MockAppLogger();
+    apiClient = MockPhasesApiClient();
+    repository = PhasesRepositoryImpl(logger, apiClient);
+  });
+
+  group('PhasesRepositoryImpl.updateWeeklyGoal', () {
+    test('returns success and sends weekly_goal when api succeeds', () async {
+      when(apiClient.updateWeeklyGoal(any)).thenAnswer((_) async {});
+
+      final result = await repository.updateWeeklyGoal(5);
+
+      expect(result.isSuccess, isTrue);
+
+      final captured = verify(apiClient.updateWeeklyGoal(captureAny)).captured.single;
+      expect(captured, {'weekly_goal': 5});
+      verifyNoMoreInteractions(apiClient);
+    });
+
+    test('returns PhasesValidationFailure when api returns validation error', () async {
+      final exception = createPhasesDioBadResponseException(
+        path: '/user/weekly-goal',
+        statusCode: 422,
+        code: 'validation_failed',
+        errors: const {
+          'weekly_goal': ['error_message'],
+        },
+      );
+      when(apiClient.updateWeeklyGoal(any)).thenThrow(exception);
+
+      final result = await repository.updateWeeklyGoal(5);
+
+      expect(result.isFailure, isTrue);
+      expect(result.failure, isA<PhasesValidationFailure>());
+      expect(result.failure!.message, 'error_message');
+      expect(result.failure!.parentException, exception);
+
+      verify(apiClient.updateWeeklyGoal(any)).called(1);
+      verifyNoMoreInteractions(apiClient);
+    });
+
+    test('returns UnknownPhasesFailure when unexpected exception occurs', () async {
+      final exception = Exception('unexpected_error');
+      when(apiClient.updateWeeklyGoal(any)).thenThrow(exception);
+
+      final result = await repository.updateWeeklyGoal(5);
+
+      expect(result.isFailure, isTrue);
+      expect(result.failure, isA<UnknownPhasesFailure>());
+      expect(result.failure!.parentException, exception);
+
+      verify(apiClient.updateWeeklyGoal(any)).called(1);
+      verifyNoMoreInteractions(apiClient);
+    });
+  });
+}

--- a/test/features/phases/presentation/cubits/weekly_goal_cubit_test.dart
+++ b/test/features/phases/presentation/cubits/weekly_goal_cubit_test.dart
@@ -1,0 +1,71 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:moveup_flutter/core/failures/feature/phases/phases_failure.dart';
+import 'package:moveup_flutter/core/result/result.dart';
+import 'package:moveup_flutter/features/phases/domain/repositories/phases_repository.dart';
+import 'package:moveup_flutter/features/phases/presentation/cubits/weekly_goal_cubit.dart';
+
+import 'weekly_goal_cubit_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<PhasesRepository>()])
+void main() {
+  late MockPhasesRepository repository;
+  late WeeklyGoalCubit cubit;
+
+  setUp(() {
+    repository = MockPhasesRepository();
+    cubit = WeeklyGoalCubit(repository);
+    provideDummy<Result<void, PhasesFailure>>(const Success<void, PhasesFailure>(null));
+  });
+
+  group('WeeklyGoalCubit', () {
+    const requestFailure = PhasesRequestFailure('request_failed');
+
+    blocTest<WeeklyGoalCubit, WeeklyGoalState>(
+      'emits inProgress only once when updateWeeklyGoal is called twice',
+      setUp: () => when(repository.updateWeeklyGoal(4)).thenAnswer(
+        (_) async => const Success<void, PhasesFailure>(null),
+      ),
+      build: () => cubit,
+      act: (cubit) {
+        cubit.updateWeeklyGoal(4);
+        cubit.updateWeeklyGoal(4);
+      },
+      expect: () => const [
+        WeeklyGoalState.inProgress(),
+        WeeklyGoalState.succeed(),
+      ],
+      verify: (_) => verify(repository.updateWeeklyGoal(4)).called(1),
+    );
+
+    blocTest<WeeklyGoalCubit, WeeklyGoalState>(
+      'emits succeed when updateWeeklyGoal succeeds',
+      setUp: () => when(repository.updateWeeklyGoal(4)).thenAnswer(
+        (_) async => const Success<void, PhasesFailure>(null),
+      ),
+      build: () => cubit,
+      act: (cubit) => cubit.updateWeeklyGoal(4),
+      expect: () => const [
+        WeeklyGoalState.inProgress(),
+        WeeklyGoalState.succeed(),
+      ],
+      verify: (_) => verify(repository.updateWeeklyGoal(4)).called(1),
+    );
+
+    blocTest<WeeklyGoalCubit, WeeklyGoalState>(
+      'emits failed(requestFailure) when updateWeeklyGoal fails',
+      setUp: () => when(repository.updateWeeklyGoal(4)).thenAnswer(
+        (_) async => const Failure(requestFailure),
+      ),
+      build: () => cubit,
+      act: (cubit) => cubit.updateWeeklyGoal(4),
+      expect: () => const [
+        WeeklyGoalState.inProgress(),
+        WeeklyGoalState.failed(requestFailure),
+      ],
+      verify: (_) => verify(repository.updateWeeklyGoal(4)).called(1),
+    );
+  });
+}

--- a/test/features/phases/support/phases_fixtures.dart
+++ b/test/features/phases/support/phases_fixtures.dart
@@ -1,0 +1,29 @@
+import 'package:dio/dio.dart';
+
+/// Test fixture for Dio bad response exception.
+DioException createPhasesDioBadResponseException({
+  required String path,
+  required int statusCode,
+  required String code,
+  String message = 'error_message',
+  Map<String, List<String>>? errors,
+}) {
+  final requestOptions = RequestOptions(path: path);
+  final data = <String, dynamic>{
+    'code': code,
+    'message': message,
+  };
+  if (errors != null) {
+    data['errors'] = errors;
+  }
+
+  return DioException(
+    requestOptions: requestOptions,
+    type: DioExceptionType.badResponse,
+    response: Response<Map<String, dynamic>>(
+      requestOptions: requestOptions,
+      statusCode: statusCode,
+      data: data,
+    ),
+  );
+}


### PR DESCRIPTION
## 🚀 Summary

Implemented the final `Fitness Start` onboarding stage for adjusting weekly training goal through `POST /api/user/weekly-goal`.

The branch adds a new shared `phases` slice for weekly-goal submission, integrates a final onboarding screen inside `fitness_start`, and moves guest onboarding completion to happen only after the weekly-goal step succeeds.

## ✨ Changes

- ✅ Added `PhasesFailure` hierarchy and feature-specific network failure mapping + unit tests
- ✅ Added `PhasesApiClient` with `updateWeeklyGoal` contract
- ✅ Added `PhasesRepository` and `PhasesRepositoryImpl` + unit tests
- ✅ Added `WeeklyGoalCubit` and `WeeklyGoalState` + unit tests
- ✅ Added final onboarding route: `/fitness-start/weekly-goal`
- ✅ Added `FitnessStartWeeklyGoalPageBuilder` and `FitnessStartWeeklyGoalPage` with updating app strings
- ✅ Updated `FitnessStartTestAttemptPage` so successful test completion now routes to the weekly-goal step instead of finishing onboarding immediately
- ✅ Updated `FitnessStartFlowAppBar` to support a no-title layout for the final onboarding page

## 💥 Breaking Changes

- Guest onboarding completion is no longer triggered directly after successful guest test completion
  - previous behavior: test attempt completion called `AuthSessionCubit.completeGuestFitnessStart()`
  - new behavior: test attempt completion routes to `/fitness-start/weekly-goal`, and onboarding is completed only after successful weekly-goal submit
- `FitnessStartFlowAppBar` now supports an empty title and omits the title widget in that case

## 🧪 Verification

- [x] `flutter analyze`
- [x] `flutter test test/features/phases`