### PR TITLE
feat(profile): add current phase section to profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Authenticated test attempt flow for `/tests/attempt/:testingId`, including auth API client methods, repository wiring, fullscreen attempt route, and the attempt UI mirrored from the Fitness Start flow.
 - Profile user section for the authenticated `/profile` tab, including `ProfileApiClient`, profile repository/failures, user section Cubits, edit-profile and change-password dialogs, avatar upload flow, and the first profile screen UI based on the provided layout.
 - Profile statistics section for the authenticated `/profile` tab, including dedicated statistics API client/repository, focused `/profile` history snapshot mapping, statistics Cubit/state flow, chart widgets, selectors, history dialog, and widget coverage for the integrated UI.
+- Profile current phase section for the authenticated `/profile` tab, reusing the bootstrap profile phase snapshot plus aggregate statistics frequency summary to render the read-only phase block without a standalone phase slice.
 
 ### Changed
 

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -297,8 +297,8 @@ abstract final class AppStrings {
 
   static String profileStatsAveragePerWeek(String value) => 'В среднем: $value / нед';
 
-  static String profileCurrentPhaseTrainingsPerWeek(String value) =>
-      'Вы тренируетесь $value раза в неделю.';
+  static String profileCurrentPhaseTrainingsPerWeek(String value, String timesLabel) =>
+      'Вы тренируетесь $value $timesLabel в неделю.';
 
   /// Builds the increase-adjustment message for a new absolute weight value.
   static String workoutExecutionAdjustmentIncrease(String weight) =>

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -262,6 +262,10 @@ abstract final class AppStrings {
   static const profileUpdateFailed = 'Не удалось обновить профиль. Попробуйте снова';
   static const profileChangePasswordFailed = 'Не удалось сменить пароль. Попробуйте снова';
   static const profileImagePickFailed = 'Не удалось выбрать изображение. Попробуйте снова';
+  static const profileCurrentPhaseTitle = 'Текущая фаза';
+  static const profileCurrentPhaseRecommendation = 'Вам рекомендуется тренироваться в неделю';
+  static const profileCurrentPhaseEmpty = 'У вас пока нет активной фазы';
+  static const profileCurrentPhaseLoadFailed = 'Не удалось загрузить текущую фазу';
   static const profileStatsTitle = 'Статистика тренировок пользователя';
   static const profileStatsHistoryButton = 'История';
   static const profileStatsVolumeMode = 'Объём';
@@ -292,6 +296,9 @@ abstract final class AppStrings {
   static const profileStatsAverageScoreLabel = 'Средняя оценка:';
 
   static String profileStatsAveragePerWeek(String value) => 'В среднем: $value / нед';
+
+  static String profileCurrentPhaseTrainingsPerWeek(String value) =>
+      'Вы тренируетесь $value раза в неделю.';
 
   /// Builds the increase-adjustment message for a new absolute weight value.
   static String workoutExecutionAdjustmentIncrease(String weight) =>

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -297,8 +297,21 @@ abstract final class AppStrings {
 
   static String profileStatsAveragePerWeek(String value) => 'В среднем: $value / нед';
 
-  static String profileCurrentPhaseTrainingsPerWeek(String value, String timesLabel) =>
-      'Вы тренируетесь $value $timesLabel в неделю.';
+  static String profileCurrentPhaseTrainingsPerWeek(int value) =>
+      'Вы тренируетесь $value ${_profileCurrentPhaseTimesLabel(value)} в неделю.';
+
+  static String _profileCurrentPhaseTimesLabel(int value) {
+    final mod100 = value % 100;
+    if (mod100 >= 11 && mod100 <= 14) {
+      return 'раз';
+    }
+
+    return switch (value % 10) {
+      1 => 'раз',
+      2 || 3 || 4 => 'раза',
+      _ => 'раз',
+    };
+  }
 
   /// Builds the increase-adjustment message for a new absolute weight value.
   static String workoutExecutionAdjustmentIncrease(String weight) =>

--- a/lib/features/profile/data/dto/profile_user_data_dto.dart
+++ b/lib/features/profile/data/dto/profile_user_data_dto.dart
@@ -22,15 +22,60 @@ class ProfileUserDataDto {
   /// Test history snapshot for profile statistics history.
   final ProfileTestsDto? tests;
 
+  /// Phase snapshot for the current phase section.
+  final ProfilePhaseDto? phase;
+
   /// Creates an instance of [ProfileUserDataDto].
   ProfileUserDataDto({
     required this.user,
     this.subscriptions,
     this.workouts,
     this.tests,
+    this.phase,
   });
 
   /// Creates a [ProfileUserDataDto] from JSON.
   factory ProfileUserDataDto.fromJson(Map<String, dynamic> json) =>
       _$ProfileUserDataDtoFromJson(json);
+}
+
+/// DTO with focused phase payload from `/profile`.
+@JsonSerializable(createToJson: false)
+class ProfilePhaseDto {
+  /// Whether the authenticated user has active phase progress.
+  @JsonKey(name: 'has_progress')
+  final bool hasProgress;
+
+  /// Current phase snapshot.
+  @JsonKey(name: 'current_phase')
+  final ProfileCurrentPhaseDto? currentPhase;
+
+  /// Creates an instance of [ProfilePhaseDto].
+  ProfilePhaseDto({
+    required this.hasProgress,
+    required this.currentPhase,
+  });
+
+  /// Creates a [ProfilePhaseDto] from JSON.
+  factory ProfilePhaseDto.fromJson(Map<String, dynamic> json) => _$ProfilePhaseDtoFromJson(json);
+}
+
+/// DTO with current phase name returned by `/profile`.
+@JsonSerializable(createToJson: false)
+class ProfileCurrentPhaseDto {
+  /// Current phase identifier.
+  final int id;
+
+  /// Current phase title.
+  final String name;
+
+  /// Creates an instance of [ProfileCurrentPhaseDto].
+  ProfileCurrentPhaseDto({
+    required this.id,
+    required this.name,
+  });
+
+  /// Creates a [ProfileCurrentPhaseDto] from JSON.
+  factory ProfileCurrentPhaseDto.fromJson(Map<String, dynamic> json) =>
+      _$ProfileCurrentPhaseDtoFromJson(json);
 }

--- a/lib/features/profile/data/dto/profile_user_data_dto.dart
+++ b/lib/features/profile/data/dto/profile_user_data_dto.dart
@@ -53,7 +53,7 @@ class ProfilePhaseDto {
   /// Creates an instance of [ProfilePhaseDto].
   ProfilePhaseDto({
     required this.hasProgress,
-    required this.currentPhase,
+    this.currentPhase,
   });
 
   /// Creates a [ProfilePhaseDto] from JSON.

--- a/lib/features/profile/data/dto/stats/profile_statistics_overview_response_dto.dart
+++ b/lib/features/profile/data/dto/stats/profile_statistics_overview_response_dto.dart
@@ -1,0 +1,67 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'profile_statistics_overview_response_dto.g.dart';
+
+/// DTO for the aggregate profile statistics overview response.
+@JsonSerializable(createToJson: false)
+class ProfileStatisticsOverviewResponseDto {
+  /// Nested overview payload.
+  final ProfileStatisticsOverviewDataDto data;
+
+  /// Creates an instance of [ProfileStatisticsOverviewResponseDto].
+  ProfileStatisticsOverviewResponseDto({required this.data});
+
+  /// Creates a [ProfileStatisticsOverviewResponseDto] from JSON.
+  factory ProfileStatisticsOverviewResponseDto.fromJson(Map<String, dynamic> json) =>
+      _$ProfileStatisticsOverviewResponseDtoFromJson(json);
+}
+
+/// DTO with focused aggregate statistics subset for the current phase section.
+@JsonSerializable(createToJson: false)
+class ProfileStatisticsOverviewDataDto {
+  /// Frequency overview subset.
+  final ProfileStatisticsOverviewFrequencyDto? frequency;
+
+  /// Creates an instance of [ProfileStatisticsOverviewDataDto].
+  ProfileStatisticsOverviewDataDto({required this.frequency});
+
+  /// Creates a [ProfileStatisticsOverviewDataDto] from JSON.
+  factory ProfileStatisticsOverviewDataDto.fromJson(Map<String, dynamic> json) =>
+      _$ProfileStatisticsOverviewDataDtoFromJson(json);
+}
+
+/// DTO with frequency subset from the aggregate statistics response.
+@JsonSerializable(createToJson: false)
+class ProfileStatisticsOverviewFrequencyDto {
+  /// Frequency summary subset.
+  final ProfileStatisticsOverviewFrequencySummaryDto? summary;
+
+  /// Creates an instance of [ProfileStatisticsOverviewFrequencyDto].
+  ProfileStatisticsOverviewFrequencyDto({required this.summary});
+
+  /// Creates a [ProfileStatisticsOverviewFrequencyDto] from JSON.
+  factory ProfileStatisticsOverviewFrequencyDto.fromJson(Map<String, dynamic> json) =>
+      _$ProfileStatisticsOverviewFrequencyDtoFromJson(json);
+}
+
+/// DTO with current phase frequency numbers for the profile section.
+@JsonSerializable(createToJson: false)
+class ProfileStatisticsOverviewFrequencySummaryDto {
+  /// Average trainings per week.
+  @JsonKey(name: 'average_per_week')
+  final double averagePerWeek;
+
+  /// Recommended weekly goal.
+  @JsonKey(name: 'weekly_goal')
+  final int weeklyGoal;
+
+  /// Creates an instance of [ProfileStatisticsOverviewFrequencySummaryDto].
+  ProfileStatisticsOverviewFrequencySummaryDto({
+    required this.averagePerWeek,
+    required this.weeklyGoal,
+  });
+
+  /// Creates a [ProfileStatisticsOverviewFrequencySummaryDto] from JSON.
+  factory ProfileStatisticsOverviewFrequencySummaryDto.fromJson(Map<String, dynamic> json) =>
+      _$ProfileStatisticsOverviewFrequencySummaryDtoFromJson(json);
+}

--- a/lib/features/profile/data/dto/stats/profile_statistics_overview_response_dto.dart
+++ b/lib/features/profile/data/dto/stats/profile_statistics_overview_response_dto.dart
@@ -23,7 +23,7 @@ class ProfileStatisticsOverviewDataDto {
   final ProfileStatisticsOverviewFrequencyDto? frequency;
 
   /// Creates an instance of [ProfileStatisticsOverviewDataDto].
-  ProfileStatisticsOverviewDataDto({required this.frequency});
+  ProfileStatisticsOverviewDataDto({this.frequency});
 
   /// Creates a [ProfileStatisticsOverviewDataDto] from JSON.
   factory ProfileStatisticsOverviewDataDto.fromJson(Map<String, dynamic> json) =>

--- a/lib/features/profile/data/mappers/profile_phase_snapshot_mapper.dart
+++ b/lib/features/profile/data/mappers/profile_phase_snapshot_mapper.dart
@@ -1,0 +1,11 @@
+import '../../domain/entities/profile_phase_snapshot.dart';
+import '../dto/profile_user_data_dto.dart';
+
+/// Maps aggregate `/profile` DTO subset to phase snapshot entities.
+extension ProfilePhaseSnapshotMapper on ProfileUserDataDto {
+  /// Returns a focused phase snapshot for the profile current phase UI.
+  ProfilePhaseSnapshot toPhaseSnapshot() => ProfilePhaseSnapshot(
+    hasProgress: phase?.hasProgress ?? false,
+    currentPhaseName: phase?.currentPhase?.name,
+  );
+}

--- a/lib/features/profile/data/mappers/profile_statistics_mapper.dart
+++ b/lib/features/profile/data/mappers/profile_statistics_mapper.dart
@@ -16,7 +16,7 @@ import '../dto/stats/volume_response_dto.dart';
 extension ProfileStatisticsOverviewMapper on ProfileStatisticsOverviewDataDto {
   /// Converts aggregate statistics overview into current phase summary data.
   ProfileCurrentPhaseSummary toCurrentPhaseSummary() => ProfileCurrentPhaseSummary(
-    averagePerWeek: frequency?.summary?.averagePerWeek ?? 0,
+    averagePerWeek: frequency?.summary?.averagePerWeek ?? 0.0,
     weeklyGoal: frequency?.summary?.weeklyGoal ?? 0,
   );
 }

--- a/lib/features/profile/data/mappers/profile_statistics_mapper.dart
+++ b/lib/features/profile/data/mappers/profile_statistics_mapper.dart
@@ -1,14 +1,25 @@
 import '../../domain/entities/profile_statistics/frequency_period.dart';
 import '../../domain/entities/profile_statistics/frequency_statistics_data.dart';
+import '../../domain/entities/profile_statistics/profile_current_phase_summary.dart';
 import '../../domain/entities/profile_statistics/profile_exercise_option.dart';
 import '../../domain/entities/profile_statistics/profile_workout_option.dart';
 import '../../domain/entities/profile_statistics/trend_statistics_data.dart';
 import '../../domain/entities/profile_statistics/volume_statistics_data.dart';
 import '../dto/stats/frequency_response_dto.dart';
 import '../dto/stats/profile_exercises_response_dto.dart';
+import '../dto/stats/profile_statistics_overview_response_dto.dart';
 import '../dto/stats/profile_workouts_response_dto.dart';
 import '../dto/stats/trend_response_dto.dart';
 import '../dto/stats/volume_response_dto.dart';
+
+/// Maps profile statistics DTOs into domain entities.
+extension ProfileStatisticsOverviewMapper on ProfileStatisticsOverviewDataDto {
+  /// Converts aggregate statistics overview into current phase summary data.
+  ProfileCurrentPhaseSummary toCurrentPhaseSummary() => ProfileCurrentPhaseSummary(
+    averagePerWeek: frequency?.summary?.averagePerWeek ?? 0,
+    weeklyGoal: frequency?.summary?.weeklyGoal ?? 0,
+  );
+}
 
 /// Maps profile statistics DTOs into domain entities.
 extension VolumeStatisticsMapper on VolumeStatisticsDto {

--- a/lib/features/profile/data/remote/profile_statistics_api_client.dart
+++ b/lib/features/profile/data/remote/profile_statistics_api_client.dart
@@ -4,6 +4,7 @@ import 'package:retrofit/retrofit.dart';
 import '../../../../core/network/api_paths.dart';
 import '../dto/stats/frequency_response_dto.dart';
 import '../dto/stats/profile_exercises_response_dto.dart';
+import '../dto/stats/profile_statistics_overview_response_dto.dart';
 import '../dto/stats/profile_workouts_response_dto.dart';
 import '../dto/stats/trend_response_dto.dart';
 import '../dto/stats/volume_response_dto.dart';
@@ -18,6 +19,10 @@ abstract class ProfileStatisticsApiClient {
     Dio dio, {
     String? baseUrl,
   }) = _ProfileStatisticsApiClient;
+
+  /// Returns aggregate profile statistics overview.
+  @GET(ApiPaths.profileStatistics)
+  Future<ProfileStatisticsOverviewResponseDto> getOverview();
 
   /// Returns volume statistics for the authenticated profile.
   @GET(ApiPaths.profileStatisticsVolume)

--- a/lib/features/profile/data/repositories/profile_repository_impl.dart
+++ b/lib/features/profile/data/repositories/profile_repository_impl.dart
@@ -57,6 +57,7 @@ final class ProfileRepositoryImpl implements ProfileRepository {
       final response = await _apiClient.getProfile();
       final snapshot = response.data.toStatsHistorySnapshot();
       _cachedStatsHistorySnapshot = snapshot;
+      _cachedPhaseSnapshot = response.data.toPhaseSnapshot();
       return Result.success(snapshot);
     } on DioException catch (e) {
       final networkFailure = e.toNetworkFailure();

--- a/lib/features/profile/data/repositories/profile_repository_impl.dart
+++ b/lib/features/profile/data/repositories/profile_repository_impl.dart
@@ -7,11 +7,13 @@ import '../../../../core/network/mappers/dio_exception_mapper.dart';
 import '../../../../core/result/result.dart';
 import '../../../../core/utils/logger/app_logger.dart';
 import '../../../auth/domain/entities/user.dart';
+import '../../domain/entities/profile_phase_snapshot.dart';
 import '../../domain/entities/profile_stats_history_snapshot.dart';
 import '../../domain/repositories/profile_repository.dart';
 import '../dto/change_password_request_dto.dart';
 import '../dto/update_profile_request_dto.dart';
 import '../mappers/profile_failure_mapper.dart';
+import '../mappers/profile_phase_snapshot_mapper.dart';
 import '../mappers/profile_history_snapshot_mapper.dart';
 import '../mappers/profile_user_entity_mapper.dart';
 import '../remote/profile_api_client.dart';
@@ -21,6 +23,7 @@ final class ProfileRepositoryImpl implements ProfileRepository {
   final AppLogger _logger;
   final ProfileApiClient _apiClient;
   ProfileStatsHistorySnapshot? _cachedStatsHistorySnapshot;
+  ProfilePhaseSnapshot? _cachedPhaseSnapshot;
 
   /// Creates an instance of [ProfileRepositoryImpl].
   ProfileRepositoryImpl(this._logger, this._apiClient);
@@ -30,6 +33,7 @@ final class ProfileRepositoryImpl implements ProfileRepository {
     try {
       final response = await _apiClient.getProfile();
       _cachedStatsHistorySnapshot = response.data.toStatsHistorySnapshot();
+      _cachedPhaseSnapshot = response.data.toPhaseSnapshot();
       return Result.success(response.data.user.toEntity());
     } on DioException catch (e) {
       final networkFailure = e.toNetworkFailure();
@@ -59,6 +63,30 @@ final class ProfileRepositoryImpl implements ProfileRepository {
       return Result.failure(networkFailure.toProfileFailure());
     } catch (e, s) {
       _logger.e('GetStatsHistorySnapshot failed with unexpected error', e, s);
+      return Result.failure(
+        UnknownProfileFailure(parentException: e, stackTrace: s),
+      );
+    }
+  }
+
+  @override
+  Future<Result<ProfilePhaseSnapshot, ProfileFailure>> getPhaseSnapshot() async {
+    final cachedPhaseSnapshot = _cachedPhaseSnapshot;
+    if (cachedPhaseSnapshot != null) {
+      return Result.success(cachedPhaseSnapshot);
+    }
+
+    try {
+      final response = await _apiClient.getProfile();
+      final snapshot = response.data.toPhaseSnapshot();
+      _cachedStatsHistorySnapshot = response.data.toStatsHistorySnapshot();
+      _cachedPhaseSnapshot = snapshot;
+      return Result.success(snapshot);
+    } on DioException catch (e) {
+      final networkFailure = e.toNetworkFailure();
+      return Result.failure(networkFailure.toProfileFailure());
+    } catch (e, s) {
+      _logger.e('GetPhaseSnapshot failed with unexpected error', e, s);
       return Result.failure(
         UnknownProfileFailure(parentException: e, stackTrace: s),
       );
@@ -102,6 +130,7 @@ final class ProfileRepositoryImpl implements ProfileRepository {
 
       final refreshedResponse = await _apiClient.getProfile();
       _cachedStatsHistorySnapshot = refreshedResponse.data.toStatsHistorySnapshot();
+      _cachedPhaseSnapshot = refreshedResponse.data.toPhaseSnapshot();
       return Result.success(refreshedResponse.data.user.toEntity());
     } on DioException catch (e) {
       final networkFailure = e.toNetworkFailure();

--- a/lib/features/profile/data/repositories/profile_statistics_repository_impl.dart
+++ b/lib/features/profile/data/repositories/profile_statistics_repository_impl.dart
@@ -6,6 +6,7 @@ import '../../../../core/result/result.dart';
 import '../../../../core/utils/logger/app_logger.dart';
 import '../../domain/entities/profile_statistics/frequency_period.dart';
 import '../../domain/entities/profile_statistics/frequency_statistics_data.dart';
+import '../../domain/entities/profile_statistics/profile_current_phase_summary.dart';
 import '../../domain/entities/profile_statistics/profile_exercise_option.dart';
 import '../../domain/entities/profile_statistics/profile_workout_option.dart';
 import '../../domain/entities/profile_statistics/trend_statistics_data.dart';
@@ -22,6 +23,22 @@ final class ProfileStatisticsRepositoryImpl implements ProfileStatisticsReposito
 
   /// Creates an instance of [ProfileStatisticsRepositoryImpl].
   ProfileStatisticsRepositoryImpl(this._logger, this._apiClient);
+
+  @override
+  Future<Result<ProfileCurrentPhaseSummary, ProfileFailure>> getCurrentPhaseSummary() async {
+    try {
+      final response = await _apiClient.getOverview();
+      return Result.success(response.data.toCurrentPhaseSummary());
+    } on DioException catch (e) {
+      final networkFailure = e.toNetworkFailure();
+      return Result.failure(networkFailure.toProfileFailure());
+    } catch (e, s) {
+      _logger.e('GetCurrentPhaseSummary failed with unexpected error', e, s);
+      return Result.failure(
+        UnknownProfileFailure(parentException: e, stackTrace: s),
+      );
+    }
+  }
 
   @override
   Future<Result<VolumeStatisticsData, ProfileFailure>> getVolume({

--- a/lib/features/profile/domain/entities/profile_phase_snapshot.dart
+++ b/lib/features/profile/domain/entities/profile_phase_snapshot.dart
@@ -1,0 +1,19 @@
+import 'package:equatable/equatable.dart';
+
+/// Focused phase snapshot used by the profile current phase section.
+final class ProfilePhaseSnapshot extends Equatable {
+  /// Whether the authenticated user has active phase progress.
+  final bool hasProgress;
+
+  /// Current phase display name.
+  final String? currentPhaseName;
+
+  /// Creates an instance of [ProfilePhaseSnapshot].
+  const ProfilePhaseSnapshot({
+    required this.hasProgress,
+    required this.currentPhaseName,
+  });
+
+  @override
+  List<Object?> get props => [hasProgress, currentPhaseName];
+}

--- a/lib/features/profile/domain/entities/profile_statistics/profile_current_phase_summary.dart
+++ b/lib/features/profile/domain/entities/profile_statistics/profile_current_phase_summary.dart
@@ -1,0 +1,19 @@
+import 'package:equatable/equatable.dart';
+
+/// Focused frequency summary used by the profile current phase section.
+final class ProfileCurrentPhaseSummary extends Equatable {
+  /// Average weekly training frequency.
+  final double averagePerWeek;
+
+  /// Recommended weekly training goal.
+  final int weeklyGoal;
+
+  /// Creates an instance of [ProfileCurrentPhaseSummary].
+  const ProfileCurrentPhaseSummary({
+    required this.averagePerWeek,
+    required this.weeklyGoal,
+  });
+
+  @override
+  List<Object?> get props => [averagePerWeek, weeklyGoal];
+}

--- a/lib/features/profile/domain/repositories/profile_repository.dart
+++ b/lib/features/profile/domain/repositories/profile_repository.dart
@@ -1,6 +1,7 @@
 import '../../../../core/failures/feature/profile/profile_failure.dart';
 import '../../../../core/result/result.dart';
 import '../../../auth/domain/entities/user.dart';
+import '../entities/profile_phase_snapshot.dart';
 import '../entities/profile_stats_history_snapshot.dart';
 
 /// Repository interface for authenticated profile operations.
@@ -10,6 +11,9 @@ abstract interface class ProfileRepository {
 
   /// Returns the current history snapshot for the statistics history modal.
   Future<Result<ProfileStatsHistorySnapshot, ProfileFailure>> getStatsHistorySnapshot();
+
+  /// Returns the current phase snapshot for the current phase section.
+  Future<Result<ProfilePhaseSnapshot, ProfileFailure>> getPhaseSnapshot();
 
   /// Updates the current user profile and returns the canonical refreshed user payload.
   Future<Result<User, ProfileFailure>> updateUser({

--- a/lib/features/profile/domain/repositories/profile_statistics_repository.dart
+++ b/lib/features/profile/domain/repositories/profile_statistics_repository.dart
@@ -1,6 +1,7 @@
 import '../../../../core/failures/feature/profile/profile_failure.dart';
 import '../../../../core/result/result.dart';
 import '../entities/profile_statistics/frequency_period.dart';
+import '../entities/profile_statistics/profile_current_phase_summary.dart';
 import '../entities/profile_statistics/frequency_statistics_data.dart';
 import '../entities/profile_statistics/profile_exercise_option.dart';
 import '../entities/profile_statistics/profile_workout_option.dart';
@@ -9,6 +10,9 @@ import '../entities/profile_statistics/volume_statistics_data.dart';
 
 /// Repository interface for profile statistics operations.
 abstract interface class ProfileStatisticsRepository {
+  /// Returns frequency summary used by the current phase section.
+  Future<Result<ProfileCurrentPhaseSummary, ProfileFailure>> getCurrentPhaseSummary();
+
   /// Returns volume statistics for the selected exercise and week offset.
   Future<Result<VolumeStatisticsData, ProfileFailure>> getVolume({
     int? exerciseId,

--- a/lib/features/profile/presentation/cubits/profile_statistics_cubit.dart
+++ b/lib/features/profile/presentation/cubits/profile_statistics_cubit.dart
@@ -5,6 +5,7 @@ import '../../../../../core/failures/feature/profile/profile_failure.dart';
 import '../../../../../core/result/result.dart';
 import '../../domain/entities/profile_statistics/frequency_period.dart';
 import '../../domain/entities/profile_statistics/frequency_statistics_data.dart';
+import '../../domain/entities/profile_statistics/profile_current_phase_summary.dart';
 import '../../domain/entities/profile_statistics/profile_exercise_option.dart';
 import '../../domain/entities/profile_statistics/profile_history_tab.dart';
 import '../../domain/entities/profile_statistics/profile_statistics_mode.dart';
@@ -28,12 +29,33 @@ final class ProfileStatisticsCubit extends Cubit<ProfileStatisticsState> {
   Future<void> loadInitial() async {
     if (state.isLoading) return;
 
-    emit(state.copyWith(isLoading: true, failure: null));
+    emit(
+      state.copyWith(
+        isLoading: true,
+        isLoadingCurrentPhaseSummary: true,
+        failure: null,
+        currentPhaseSummaryFailure: null,
+      ),
+    );
 
-    final volumeResult = await _repository.getVolume();
-    final exercisesResult = await _repository.getExercises();
+    final volumeFuture = _repository.getVolume();
+    final exercisesFuture = _repository.getExercises();
+    final currentPhaseSummaryFuture = _repository.getCurrentPhaseSummary();
+
+    final volumeResult = await volumeFuture;
+    final exercisesResult = await exercisesFuture;
+    final currentPhaseSummaryResult = await currentPhaseSummaryFuture;
 
     if (isClosed) return;
+
+    final currentPhaseSummary = switch (currentPhaseSummaryResult) {
+      Success(data: final summary) => summary,
+      Failure() => state.currentPhaseSummary,
+    };
+    final currentPhaseSummaryFailure = switch (currentPhaseSummaryResult) {
+      Success() => null,
+      Failure(:final error) => error,
+    };
 
     switch (volumeResult) {
       case Success(data: final volumeData):
@@ -44,10 +66,13 @@ final class ProfileStatisticsCubit extends Cubit<ProfileStatisticsState> {
         emit(
           state.copyWith(
             isLoading: false,
+            isLoadingCurrentPhaseSummary: false,
             mode: ProfileStatisticsMode.volume,
             selectedExerciseId: volumeData.exerciseId,
+            currentPhaseSummary: currentPhaseSummary,
             volumeData: volumeData,
             exerciseOptions: exerciseOptions,
+            currentPhaseSummaryFailure: currentPhaseSummaryFailure,
             failure: null,
           ),
         );
@@ -55,6 +80,9 @@ final class ProfileStatisticsCubit extends Cubit<ProfileStatisticsState> {
         emit(
           state.copyWith(
             isLoading: false,
+            isLoadingCurrentPhaseSummary: false,
+            currentPhaseSummary: currentPhaseSummary,
+            currentPhaseSummaryFailure: currentPhaseSummaryFailure,
             failure: error,
           ),
         );
@@ -199,6 +227,39 @@ final class ProfileStatisticsCubit extends Cubit<ProfileStatisticsState> {
         await _loadTrend(
           workoutId: state.selectedWorkoutId,
           loadWorkouts: state.workoutOptions.isEmpty,
+        );
+    }
+  }
+
+  /// Reloads only the current phase summary data used by the profile phase section.
+  Future<void> reloadCurrentPhaseSummary() async {
+    if (state.isLoadingCurrentPhaseSummary) return;
+
+    emit(
+      state.copyWith(
+        isLoadingCurrentPhaseSummary: true,
+        currentPhaseSummaryFailure: null,
+      ),
+    );
+
+    final result = await _repository.getCurrentPhaseSummary();
+    if (isClosed) return;
+
+    switch (result) {
+      case Success(data: final summary):
+        emit(
+          state.copyWith(
+            isLoadingCurrentPhaseSummary: false,
+            currentPhaseSummary: summary,
+            currentPhaseSummaryFailure: null,
+          ),
+        );
+      case Failure(:final error):
+        emit(
+          state.copyWith(
+            isLoadingCurrentPhaseSummary: false,
+            currentPhaseSummaryFailure: error,
+          ),
         );
     }
   }

--- a/lib/features/profile/presentation/cubits/profile_statistics_state.dart
+++ b/lib/features/profile/presentation/cubits/profile_statistics_state.dart
@@ -6,6 +6,7 @@ abstract class ProfileStatisticsState with _$ProfileStatisticsState {
   /// Creates an instance of [ProfileStatisticsState].
   const factory ProfileStatisticsState({
     @Default(false) bool isLoading,
+    @Default(false) bool isLoadingCurrentPhaseSummary,
     @Default(ProfileStatisticsMode.volume) ProfileStatisticsMode mode,
     @Default(ProfileHistoryTab.subscriptions) ProfileHistoryTab selectedHistoryTab,
     int? selectedExerciseId,
@@ -13,11 +14,13 @@ abstract class ProfileStatisticsState with _$ProfileStatisticsState {
     @Default(FrequencyPeriod.month) FrequencyPeriod selectedFrequencyPeriod,
     @Default(0) int selectedFrequencyOffset,
     ProfileStatsHistorySnapshot? historySnapshot,
+    ProfileCurrentPhaseSummary? currentPhaseSummary,
     VolumeStatisticsData? volumeData,
     FrequencyStatisticsData? frequencyData,
     TrendStatisticsData? trendData,
     @Default(<ProfileExerciseOption>[]) List<ProfileExerciseOption> exerciseOptions,
     @Default(<ProfileWorkoutOption>[]) List<ProfileWorkoutOption> workoutOptions,
+    ProfileFailure? currentPhaseSummaryFailure,
     ProfileFailure? failure,
   }) = _ProfileStatisticsState;
 }

--- a/lib/features/profile/presentation/cubits/profile_user_cubit.dart
+++ b/lib/features/profile/presentation/cubits/profile_user_cubit.dart
@@ -4,6 +4,7 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 import '../../../../../core/failures/feature/profile/profile_failure.dart';
 import '../../../../../core/result/result.dart';
 import '../../../auth/domain/entities/user.dart';
+import '../../domain/entities/profile_phase_snapshot.dart';
 import '../../domain/entities/profile_stats_history_snapshot.dart';
 import '../../domain/repositories/profile_repository.dart';
 
@@ -38,16 +39,23 @@ final class ProfileUserCubit extends Cubit<ProfileUserState> {
       case Success(data: final user):
         final historyResult = await _repository.getStatsHistorySnapshot();
         if (isClosed) return;
+        final phaseResult = await _repository.getPhaseSnapshot();
+        if (isClosed) return;
 
         final historySnapshot = switch (historyResult) {
           Success(data: final snapshot) => snapshot,
           Failure() => state.historySnapshot,
+        };
+        final phaseSnapshot = switch (phaseResult) {
+          Success(data: final snapshot) => snapshot,
+          Failure() => state.phaseSnapshot,
         };
         emit(
           state.copyWith(
             isLoading: false,
             user: user,
             historySnapshot: historySnapshot,
+            phaseSnapshot: phaseSnapshot,
             failure: null,
           ),
         );

--- a/lib/features/profile/presentation/cubits/profile_user_state.dart
+++ b/lib/features/profile/presentation/cubits/profile_user_state.dart
@@ -8,6 +8,7 @@ abstract class ProfileUserState with _$ProfileUserState {
     @Default(false) bool isLoading,
     User? user,
     ProfileStatsHistorySnapshot? historySnapshot,
+    ProfilePhaseSnapshot? phaseSnapshot,
     ProfileFailure? failure,
   }) = _ProfileUserState;
 }

--- a/lib/features/profile/presentation/pages/profile_page.dart
+++ b/lib/features/profile/presentation/pages/profile_page.dart
@@ -17,6 +17,7 @@ import '../../../auth/presentation/cubits/auth_session_cubit.dart';
 import '../cubits/profile_statistics_cubit.dart';
 import '../cubits/profile_user_cubit.dart';
 import '../widgets/change_password_dialog.dart';
+import '../widgets/current_phase_section_widget.dart';
 import '../widgets/edit_profile_dialog.dart';
 import '../widgets/stats/profile_history_dialog.dart';
 import '../widgets/stats/stats_section_widget.dart';
@@ -111,6 +112,8 @@ class ProfilePage extends StatelessWidget {
                     onPressed: () => _openHistoryDialog(context),
                     child: const Text(AppStrings.profileStatsHistoryButton),
                   ),
+                  const SizedBox(height: 36),
+                  const CurrentPhaseSectionWidget(),
                 ],
               ),
             );

--- a/lib/features/profile/presentation/widgets/current_phase_section_widget.dart
+++ b/lib/features/profile/presentation/widgets/current_phase_section_widget.dart
@@ -260,7 +260,7 @@ final class _CurrentPhaseSummaryText extends StatelessWidget {
     final textTheme = AppTextTheme.of(context);
 
     return Text(
-      '${AppStrings.profileCurrentPhaseTrainingsPerWeek('$averagePerWeek', _buildTimesLabel(averagePerWeek))}\n'
+      '${AppStrings.profileCurrentPhaseTrainingsPerWeek(averagePerWeek)}\n'
       '${AppStrings.profileCurrentPhaseRecommendation}',
       maxLines: 3,
       overflow: TextOverflow.ellipsis,
@@ -303,17 +303,4 @@ final class _CurrentPhaseGoalBox extends StatelessWidget {
       ),
     );
   }
-}
-
-String _buildTimesLabel(int value) {
-  final mod100 = value % 100;
-  if (mod100 >= 11 && mod100 <= 14) {
-    return 'раз';
-  }
-
-  return switch (value % 10) {
-    1 => 'раз',
-    2 || 3 || 4 => 'раза',
-    _ => 'раз',
-  };
 }

--- a/lib/features/profile/presentation/widgets/current_phase_section_widget.dart
+++ b/lib/features/profile/presentation/widgets/current_phase_section_widget.dart
@@ -1,0 +1,312 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../../core/constants/app_strings.dart';
+import '../../../../../uikit/buttons/button_state.dart';
+import '../../../../../uikit/buttons/main_button.dart';
+import '../../../../../uikit/themes/colors/app_color_theme.dart';
+import '../../../../../uikit/themes/text/app_text_theme.dart';
+import '../cubits/profile_statistics_cubit.dart';
+import '../cubits/profile_user_cubit.dart';
+
+/// Read-only profile section with the current phase name and summary numbers.
+class CurrentPhaseSectionWidget extends StatelessWidget {
+  /// Creates an instance of [CurrentPhaseSectionWidget].
+  const CurrentPhaseSectionWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<ProfileUserCubit, ProfileUserState>(
+      buildWhen: (previous, current) =>
+          previous.phaseSnapshot != current.phaseSnapshot ||
+          previous.isLoading != current.isLoading,
+      builder: (context, userState) {
+        final phaseSnapshot = userState.phaseSnapshot;
+        if (phaseSnapshot == null) {
+          return _CurrentPhaseErrorState(
+            onRetryPressed: () => context.read<ProfileUserCubit>().refresh(),
+            isLoading: userState.isLoading,
+          );
+        }
+
+        if (!phaseSnapshot.hasProgress || (phaseSnapshot.currentPhaseName?.isEmpty ?? true)) {
+          return _CurrentPhaseEmptyState(
+            currentPhaseName: phaseSnapshot.currentPhaseName,
+          );
+        }
+
+        return BlocBuilder<ProfileStatisticsCubit, ProfileStatisticsState>(
+          buildWhen: (previous, current) =>
+              previous.currentPhaseSummary != current.currentPhaseSummary ||
+              previous.isLoadingCurrentPhaseSummary != current.isLoadingCurrentPhaseSummary ||
+              previous.currentPhaseSummaryFailure != current.currentPhaseSummaryFailure,
+          builder: (context, statisticsState) {
+            final currentPhaseSummary = statisticsState.currentPhaseSummary;
+            if (currentPhaseSummary == null) {
+              if (statisticsState.isLoadingCurrentPhaseSummary) {
+                return _CurrentPhaseLoadingState(
+                  currentPhaseName: phaseSnapshot.currentPhaseName!,
+                );
+              }
+
+              return _CurrentPhaseErrorState(
+                currentPhaseName: phaseSnapshot.currentPhaseName,
+                onRetryPressed: () =>
+                    context.read<ProfileStatisticsCubit>().reloadCurrentPhaseSummary(),
+                isLoading: false,
+              );
+            }
+
+            return _CurrentPhaseContent(
+              currentPhaseName: phaseSnapshot.currentPhaseName!,
+              averagePerWeek: _formatAveragePerWeek(currentPhaseSummary.averagePerWeek),
+              weeklyGoal: '${currentPhaseSummary.weeklyGoal}',
+            );
+          },
+        );
+      },
+    );
+  }
+}
+
+final class _CurrentPhaseContent extends StatelessWidget {
+  final String currentPhaseName;
+  final String averagePerWeek;
+  final String weeklyGoal;
+
+  const _CurrentPhaseContent({
+    required this.currentPhaseName,
+    required this.averagePerWeek,
+    required this.weeklyGoal,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _CurrentPhaseTitle(),
+        const SizedBox(height: 4),
+        _CurrentPhaseNameField(currentPhaseName: currentPhaseName),
+        const SizedBox(height: 20),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: _CurrentPhaseSummaryText(averagePerWeek: averagePerWeek),
+            ),
+            Padding(
+              padding: const EdgeInsets.only(right: 31),
+              child: _CurrentPhaseGoalBox(weeklyGoal: weeklyGoal),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+final class _CurrentPhaseLoadingState extends StatelessWidget {
+  final String currentPhaseName;
+
+  const _CurrentPhaseLoadingState({
+    required this.currentPhaseName,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _CurrentPhaseTitle(),
+        const SizedBox(height: 4),
+        _CurrentPhaseNameField(currentPhaseName: currentPhaseName),
+        const SizedBox(height: 20),
+        const Center(
+          child: SizedBox.square(
+            dimension: 24,
+            child: CircularProgressIndicator.adaptive(strokeWidth: 2),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+final class _CurrentPhaseErrorState extends StatelessWidget {
+  final String? currentPhaseName;
+  final VoidCallback onRetryPressed;
+  final bool isLoading;
+
+  const _CurrentPhaseErrorState({
+    required this.onRetryPressed,
+    required this.isLoading,
+    this.currentPhaseName,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorTheme = AppColorTheme.of(context);
+    final textTheme = AppTextTheme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _CurrentPhaseTitle(),
+        const SizedBox(height: 4),
+        _CurrentPhaseNameField(
+          currentPhaseName: currentPhaseName ?? AppStrings.profileCurrentPhaseEmpty,
+        ),
+        const SizedBox(height: 20),
+        Text(
+          AppStrings.profileCurrentPhaseLoadFailed,
+          style: textTheme.body.copyWith(color: colorTheme.onSurface),
+        ),
+        const SizedBox(height: 16),
+        MainButton(
+          state: isLoading ? ButtonState.loading : ButtonState.enabled,
+          onPressed: onRetryPressed,
+          child: const Text(AppStrings.retryButton),
+        ),
+      ],
+    );
+  }
+}
+
+final class _CurrentPhaseEmptyState extends StatelessWidget {
+  final String? currentPhaseName;
+
+  const _CurrentPhaseEmptyState({
+    this.currentPhaseName,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorTheme = AppColorTheme.of(context);
+    final textTheme = AppTextTheme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _CurrentPhaseTitle(),
+        const SizedBox(height: 4),
+        _CurrentPhaseNameField(
+          currentPhaseName: currentPhaseName ?? AppStrings.profileCurrentPhaseEmpty,
+        ),
+        const SizedBox(height: 20),
+        Text(
+          AppStrings.profileCurrentPhaseEmpty,
+          style: textTheme.body.copyWith(color: colorTheme.onSurface),
+        ),
+      ],
+    );
+  }
+}
+
+final class _CurrentPhaseTitle extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final colorTheme = AppColorTheme.of(context);
+    final textTheme = AppTextTheme.of(context);
+
+    return Text(
+      AppStrings.profileCurrentPhaseTitle,
+      style: textTheme.bodyMedium.copyWith(
+        color: colorTheme.onSurface,
+      ),
+    );
+  }
+}
+
+final class _CurrentPhaseNameField extends StatelessWidget {
+  final String currentPhaseName;
+
+  const _CurrentPhaseNameField({
+    required this.currentPhaseName,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorTheme = AppColorTheme.of(context);
+    final textTheme = AppTextTheme.of(context);
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: colorTheme.outline),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Text(
+          currentPhaseName,
+          style: textTheme.bodyMedium.copyWith(
+            color: colorTheme.darkHint,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+final class _CurrentPhaseSummaryText extends StatelessWidget {
+  final String averagePerWeek;
+
+  const _CurrentPhaseSummaryText({
+    required this.averagePerWeek,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorTheme = AppColorTheme.of(context);
+    final textTheme = AppTextTheme.of(context);
+
+    return Text(
+      '${AppStrings.profileCurrentPhaseTrainingsPerWeek(averagePerWeek)}\n'
+      '${AppStrings.profileCurrentPhaseRecommendation}',
+      style: textTheme.body.copyWith(
+        color: colorTheme.onSurface,
+      ),
+    );
+  }
+}
+
+final class _CurrentPhaseGoalBox extends StatelessWidget {
+  final String weeklyGoal;
+
+  const _CurrentPhaseGoalBox({
+    required this.weeklyGoal,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorTheme = AppColorTheme.of(context);
+    final textTheme = AppTextTheme.of(context);
+
+    return SizedBox(
+      width: 41,
+      height: 41,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(10),
+          border: Border.all(color: colorTheme.outline),
+        ),
+        child: Center(
+          child: Text(
+            weeklyGoal,
+            style: textTheme.bodyMedium.copyWith(
+              color: colorTheme.darkHint,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+String _formatAveragePerWeek(double value) {
+  if (value == value.roundToDouble()) {
+    return value.toStringAsFixed(0);
+  }
+
+  return value.toStringAsFixed(1).replaceFirst('.', ',');
+}

--- a/lib/features/profile/presentation/widgets/current_phase_section_widget.dart
+++ b/lib/features/profile/presentation/widgets/current_phase_section_widget.dart
@@ -59,7 +59,7 @@ class CurrentPhaseSectionWidget extends StatelessWidget {
 
             return _CurrentPhaseContent(
               currentPhaseName: phaseSnapshot.currentPhaseName!,
-              averagePerWeek: _formatAveragePerWeek(currentPhaseSummary.averagePerWeek),
+              averagePerWeek: currentPhaseSummary.averagePerWeek.round(),
               weeklyGoal: '${currentPhaseSummary.weeklyGoal}',
             );
           },
@@ -71,7 +71,7 @@ class CurrentPhaseSectionWidget extends StatelessWidget {
 
 final class _CurrentPhaseContent extends StatelessWidget {
   final String currentPhaseName;
-  final String averagePerWeek;
+  final int averagePerWeek;
   final String weeklyGoal;
 
   const _CurrentPhaseContent({
@@ -90,7 +90,6 @@ final class _CurrentPhaseContent extends StatelessWidget {
         _CurrentPhaseNameField(currentPhaseName: currentPhaseName),
         const SizedBox(height: 20),
         Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Expanded(
               child: _CurrentPhaseSummaryText(averagePerWeek: averagePerWeek),
@@ -232,11 +231,11 @@ final class _CurrentPhaseNameField extends StatelessWidget {
 
     return DecoratedBox(
       decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(10),
+        borderRadius: BorderRadius.circular(12),
         border: Border.all(color: colorTheme.outline),
       ),
       child: Padding(
-        padding: const EdgeInsets.all(16),
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
         child: Text(
           currentPhaseName,
           style: textTheme.bodyMedium.copyWith(
@@ -249,7 +248,7 @@ final class _CurrentPhaseNameField extends StatelessWidget {
 }
 
 final class _CurrentPhaseSummaryText extends StatelessWidget {
-  final String averagePerWeek;
+  final int averagePerWeek;
 
   const _CurrentPhaseSummaryText({
     required this.averagePerWeek,
@@ -261,8 +260,11 @@ final class _CurrentPhaseSummaryText extends StatelessWidget {
     final textTheme = AppTextTheme.of(context);
 
     return Text(
-      '${AppStrings.profileCurrentPhaseTrainingsPerWeek(averagePerWeek)}\n'
+      '${AppStrings.profileCurrentPhaseTrainingsPerWeek('$averagePerWeek', _buildTimesLabel(averagePerWeek))}\n'
       '${AppStrings.profileCurrentPhaseRecommendation}',
+      maxLines: 3,
+      overflow: TextOverflow.ellipsis,
+      textAlign: TextAlign.start,
       style: textTheme.body.copyWith(
         color: colorTheme.onSurface,
       ),
@@ -287,7 +289,7 @@ final class _CurrentPhaseGoalBox extends StatelessWidget {
       height: 41,
       child: DecoratedBox(
         decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(10),
+          borderRadius: BorderRadius.circular(6),
           border: Border.all(color: colorTheme.outline),
         ),
         child: Center(
@@ -303,10 +305,15 @@ final class _CurrentPhaseGoalBox extends StatelessWidget {
   }
 }
 
-String _formatAveragePerWeek(double value) {
-  if (value == value.roundToDouble()) {
-    return value.toStringAsFixed(0);
+String _buildTimesLabel(int value) {
+  final mod100 = value % 100;
+  if (mod100 >= 11 && mod100 <= 14) {
+    return 'раз';
   }
 
-  return value.toStringAsFixed(1).replaceFirst('.', ',');
+  return switch (value % 10) {
+    1 => 'раз',
+    2 || 3 || 4 => 'раза',
+    _ => 'раз',
+  };
 }

--- a/test/features/profile/data/repositories/profile_repository_impl_test.dart
+++ b/test/features/profile/data/repositories/profile_repository_impl_test.dart
@@ -10,6 +10,7 @@ import 'package:moveup_flutter/features/profile/data/dto/change_password_request
 import 'package:moveup_flutter/features/profile/data/dto/update_profile_request_dto.dart';
 import 'package:moveup_flutter/features/profile/data/remote/profile_api_client.dart';
 import 'package:moveup_flutter/features/profile/data/repositories/profile_repository_impl.dart';
+import 'package:moveup_flutter/features/profile/domain/entities/profile_phase_snapshot.dart';
 import 'package:moveup_flutter/features/profile/domain/entities/profile_stats_history_snapshot.dart';
 import 'package:moveup_flutter/features/profile/domain/repositories/profile_repository.dart';
 
@@ -361,6 +362,120 @@ void main() {
         expect(result.failure!.parentException, exception);
 
         verify(apiClient.getProfile()).called(1);
+        verifyNoMoreInteractions(apiClient);
+      });
+
+      test('returns UnknownProfileFailure when unexpected exception occurs', () async {
+        // Arrange
+        final exception = Exception('unexpected_error');
+        when(apiClient.getProfile()).thenThrow(exception);
+
+        // Act
+        final result = await repository.getStatsHistorySnapshot();
+
+        // Assert
+        expect(result.isFailure, isTrue);
+        expect(result.failure, isA<UnknownProfileFailure>());
+        expect(result.failure!.parentException, exception);
+
+        verify(apiClient.getProfile()).called(1);
+        verify(logger.e(any, exception, any)).called(1);
+        verifyNoMoreInteractions(apiClient);
+      });
+    });
+
+    group('getPhaseSnapshot', () {
+      test('returns snapshot from cache after getUser succeeds', () async {
+        // Arrange
+        when(
+          apiClient.getProfile(),
+        ).thenAnswer(
+          (_) async => createProfileUserResponseDto(
+            phase: createProfilePhaseDto(),
+          ),
+        );
+
+        // Act
+        final getUserResult = await repository.getUser();
+        final phaseResult = await repository.getPhaseSnapshot();
+
+        // Assert
+        expect(getUserResult.isSuccess, isTrue);
+        expect(phaseResult.isSuccess, isTrue);
+        expect(phaseResult.success, createProfilePhaseSnapshot());
+
+        verify(apiClient.getProfile()).called(1);
+        verifyNoMoreInteractions(apiClient);
+      });
+
+      test('returns phase snapshot from /profile when cache is empty', () async {
+        // Arrange
+        when(
+          apiClient.getProfile(),
+        ).thenAnswer(
+          (_) async => createProfileUserResponseDto(
+            phase: createProfilePhaseDto(
+              currentPhase: createProfileCurrentPhaseDto(
+                id: 12,
+                name: 'B2',
+              ),
+            ),
+          ),
+        );
+
+        // Act
+        final result = await repository.getPhaseSnapshot();
+
+        // Assert
+        expect(result.isSuccess, isTrue);
+        expect(
+          result.success,
+          const ProfilePhaseSnapshot(
+            hasProgress: true,
+            currentPhaseName: 'B2',
+          ),
+        );
+
+        verify(apiClient.getProfile()).called(1);
+        verifyNoMoreInteractions(apiClient);
+      });
+
+      test('returns ProfileRequestFailure when api returns server error', () async {
+        // Arrange
+        final exception = createProfileDioBadResponseException(
+          path: '/api/profile',
+          statusCode: 500,
+          code: 'server_error',
+        );
+        when(apiClient.getProfile()).thenThrow(exception);
+
+        // Act
+        final result = await repository.getPhaseSnapshot();
+
+        // Assert
+        expect(result.isFailure, isTrue);
+        expect(result.failure, isA<ProfileRequestFailure>());
+        expect(result.failure!.parentException, exception);
+
+        verify(apiClient.getProfile()).called(1);
+        verifyNoMoreInteractions(apiClient);
+      });
+
+      test('returns UnknownProfileFailure when unexpected exception occurs', () async {
+        // Arrange
+        final exception = Exception('unexpected_error');
+        when(apiClient.getProfile()).thenThrow(exception);
+
+        // Act
+        final result = await repository.getPhaseSnapshot();
+
+        // Assert
+        expect(result.isFailure, isTrue);
+        expect(result.failure, isA<UnknownProfileFailure>());
+        expect(result.failure!.parentException, exception);
+
+        verify(apiClient.getProfile()).called(1);
+        verify(logger.e(any, exception, any)).called(1);
         verifyNoMoreInteractions(apiClient);
       });
     });

--- a/test/features/profile/data/repositories/profile_statistics_repository_impl_test.dart
+++ b/test/features/profile/data/repositories/profile_statistics_repository_impl_test.dart
@@ -27,6 +27,64 @@ void main() {
   });
 
   group('ProfileStatisticsRepositoryImpl', () {
+    group('getCurrentPhaseSummary()', () {
+      test('returns success(data) when api succeeds', () async {
+        // Arrange
+        when(
+          apiClient.getOverview(),
+        ).thenAnswer((_) async => createProfileStatisticsOverviewResponseDto());
+
+        // Act
+        final result = await repository.getCurrentPhaseSummary();
+
+        // Assert
+        expect(result.isSuccess, isTrue);
+        expect(result.success, testProfileCurrentPhaseSummary);
+
+        verify(apiClient.getOverview()).called(1);
+        verifyNoMoreInteractions(apiClient);
+      });
+
+      test('returns ProfileRequestFailure when api fails', () async {
+        // Arrange
+        final exception = createProfileStatisticsDioBadResponseException(
+          path: '/api/profile/statistics',
+          statusCode: 500,
+          code: 'server_error',
+        );
+        when(apiClient.getOverview()).thenThrow(exception);
+
+        // Act
+        final result = await repository.getCurrentPhaseSummary();
+
+        // Assert
+        expect(result.isFailure, isTrue);
+        expect(result.failure, isA<ProfileRequestFailure>());
+        expect(result.failure!.parentException, exception);
+
+        verify(apiClient.getOverview()).called(1);
+        verifyNoMoreInteractions(apiClient);
+      });
+
+      test('returns UnknownProfileFailure when unexpected exception occurs', () async {
+        // Arrange
+        final exception = Exception('unexpected_error');
+        when(apiClient.getOverview()).thenThrow(exception);
+
+        // Act
+        final result = await repository.getCurrentPhaseSummary();
+
+        // Assert
+        expect(result.isFailure, isTrue);
+        expect(result.failure, isA<UnknownProfileFailure>());
+        expect(result.failure!.parentException, exception);
+
+        verify(apiClient.getOverview()).called(1);
+        verify(logger.e(any, exception, any)).called(1);
+        verifyNoMoreInteractions(apiClient);
+      });
+    });
+
     group('getVolume()', () {
       test('returns success(data) when api succeeds', () async {
         // Arrange

--- a/test/features/profile/presentation/cubits/profile_statistics_cubit_test.dart
+++ b/test/features/profile/presentation/cubits/profile_statistics_cubit_test.dart
@@ -6,6 +6,7 @@ import 'package:moveup_flutter/core/failures/feature/profile/profile_failure.dar
 import 'package:moveup_flutter/core/result/result.dart';
 import 'package:moveup_flutter/features/profile/domain/entities/profile_statistics/frequency_period.dart';
 import 'package:moveup_flutter/features/profile/domain/entities/profile_statistics/frequency_statistics_data.dart';
+import 'package:moveup_flutter/features/profile/domain/entities/profile_statistics/profile_current_phase_summary.dart';
 import 'package:moveup_flutter/features/profile/domain/entities/profile_statistics/profile_exercise_option.dart';
 import 'package:moveup_flutter/features/profile/domain/entities/profile_statistics/profile_history_tab.dart';
 import 'package:moveup_flutter/features/profile/domain/entities/profile_statistics/profile_statistics_mode.dart';
@@ -36,6 +37,9 @@ void main() {
     provideDummy<Result<FrequencyStatisticsData, ProfileFailure>>(
       const Success(testProfileStatisticsFrequencyData),
     );
+    provideDummy<Result<ProfileCurrentPhaseSummary, ProfileFailure>>(
+      const Success(testProfileCurrentPhaseSummary),
+    );
     provideDummy<Result<List<ProfileExerciseOption>, ProfileFailure>>(
       const Success(testProfileStatisticsExercises),
     );
@@ -51,6 +55,9 @@ void main() {
         when(repository.getVolume()).thenAnswer(
           (_) async => const Success(testProfileStatisticsVolumeData),
         );
+        when(repository.getCurrentPhaseSummary()).thenAnswer(
+          (_) async => const Success(testProfileCurrentPhaseSummary),
+        );
         when(repository.getExercises()).thenAnswer(
           (_) async => const Success(testProfileStatisticsExercises),
         );
@@ -60,15 +67,18 @@ void main() {
       expect: () => const [
         ProfileStatisticsState(
           isLoading: true,
+          isLoadingCurrentPhaseSummary: true,
         ),
         ProfileStatisticsState(
           selectedExerciseId: 17,
+          currentPhaseSummary: testProfileCurrentPhaseSummary,
           volumeData: testProfileStatisticsVolumeData,
           exerciseOptions: testProfileStatisticsExercises,
         ),
       ],
       verify: (_) {
         verify(repository.getVolume()).called(1);
+        verify(repository.getCurrentPhaseSummary()).called(1);
         verify(repository.getExercises()).called(1);
       },
     );
@@ -77,6 +87,9 @@ void main() {
       'stores failure when initial volume load fails',
       setUp: () {
         when(repository.getVolume()).thenAnswer((_) async => const Failure(failure));
+        when(repository.getCurrentPhaseSummary()).thenAnswer(
+          (_) async => const Success(testProfileCurrentPhaseSummary),
+        );
         when(repository.getExercises()).thenAnswer(
           (_) async => const Success(testProfileStatisticsExercises),
         );
@@ -86,15 +99,91 @@ void main() {
       expect: () => const [
         ProfileStatisticsState(
           isLoading: true,
+          isLoadingCurrentPhaseSummary: true,
         ),
         ProfileStatisticsState(
+          currentPhaseSummary: testProfileCurrentPhaseSummary,
           failure: failure,
         ),
       ],
       verify: (_) {
         verify(repository.getVolume()).called(1);
+        verify(repository.getCurrentPhaseSummary()).called(1);
         verify(repository.getExercises()).called(1);
       },
+    );
+
+    blocTest<ProfileStatisticsCubit, ProfileStatisticsState>(
+      'reloads current phase summary without affecting statistics mode payload',
+      setUp: () => when(
+        repository.getCurrentPhaseSummary(),
+      ).thenAnswer((_) async => const Success(testProfileCurrentPhaseSummary)),
+      build: () => cubit,
+      seed: () => const ProfileStatisticsState(
+        selectedExerciseId: 17,
+        volumeData: testProfileStatisticsVolumeData,
+        exerciseOptions: testProfileStatisticsExercises,
+      ),
+      act: (cubit) => cubit.reloadCurrentPhaseSummary(),
+      expect: () => const [
+        ProfileStatisticsState(
+          isLoadingCurrentPhaseSummary: true,
+          selectedExerciseId: 17,
+          volumeData: testProfileStatisticsVolumeData,
+          exerciseOptions: testProfileStatisticsExercises,
+        ),
+        ProfileStatisticsState(
+          selectedExerciseId: 17,
+          currentPhaseSummary: testProfileCurrentPhaseSummary,
+          volumeData: testProfileStatisticsVolumeData,
+          exerciseOptions: testProfileStatisticsExercises,
+        ),
+      ],
+      verify: (_) => verify(repository.getCurrentPhaseSummary()).called(1),
+    );
+
+    blocTest<ProfileStatisticsCubit, ProfileStatisticsState>(
+      'stores failure when reloading current phase summary fails',
+      setUp: () => when(
+        repository.getCurrentPhaseSummary(),
+      ).thenAnswer((_) async => const Failure(failure)),
+      build: () => cubit,
+      seed: () => const ProfileStatisticsState(
+        currentPhaseSummary: testProfileCurrentPhaseSummary,
+      ),
+      act: (cubit) => cubit.reloadCurrentPhaseSummary(),
+      expect: () => const [
+        ProfileStatisticsState(
+          isLoadingCurrentPhaseSummary: true,
+          currentPhaseSummary: testProfileCurrentPhaseSummary,
+        ),
+        ProfileStatisticsState(
+          currentPhaseSummary: testProfileCurrentPhaseSummary,
+          currentPhaseSummaryFailure: failure,
+        ),
+      ],
+      verify: (_) => verify(repository.getCurrentPhaseSummary()).called(1),
+    );
+
+    blocTest<ProfileStatisticsCubit, ProfileStatisticsState>(
+      'reloadCurrentPhaseSummary ignores repeated calls while request is in progress',
+      setUp: () => when(
+        repository.getCurrentPhaseSummary(),
+      ).thenAnswer((_) async => const Success(testProfileCurrentPhaseSummary)),
+      build: () => cubit,
+      act: (cubit) {
+        cubit.reloadCurrentPhaseSummary();
+        cubit.reloadCurrentPhaseSummary();
+      },
+      expect: () => const [
+        ProfileStatisticsState(
+          isLoadingCurrentPhaseSummary: true,
+        ),
+        ProfileStatisticsState(
+          currentPhaseSummary: testProfileCurrentPhaseSummary,
+        ),
+      ],
+      verify: (_) => verify(repository.getCurrentPhaseSummary()).called(1),
     );
 
     blocTest<ProfileStatisticsCubit, ProfileStatisticsState>(

--- a/test/features/profile/presentation/cubits/profile_user_cubit_test.dart
+++ b/test/features/profile/presentation/cubits/profile_user_cubit_test.dart
@@ -5,6 +5,7 @@ import 'package:mockito/mockito.dart';
 import 'package:moveup_flutter/core/failures/feature/profile/profile_failure.dart';
 import 'package:moveup_flutter/core/result/result.dart';
 import 'package:moveup_flutter/features/auth/domain/entities/user.dart';
+import 'package:moveup_flutter/features/profile/domain/entities/profile_phase_snapshot.dart';
 import 'package:moveup_flutter/features/profile/domain/entities/profile_stats_history_snapshot.dart';
 import 'package:moveup_flutter/features/profile/domain/repositories/profile_repository.dart';
 import 'package:moveup_flutter/features/profile/presentation/cubits/profile_user_cubit.dart';
@@ -37,6 +38,9 @@ void main() {
     provideDummy<Result<ProfileStatsHistorySnapshot, ProfileFailure>>(
       Success(createProfileStatsHistorySnapshot()),
     );
+    provideDummy<Result<ProfilePhaseSnapshot, ProfileFailure>>(
+      Success(createProfilePhaseSnapshot()),
+    );
   });
 
   group('ProfileUserCubit', () {
@@ -46,6 +50,9 @@ void main() {
         when(repository.getUser()).thenAnswer((_) async => const Success(updatedUser));
         when(repository.getStatsHistorySnapshot()).thenAnswer(
           (_) async => Success(createProfileStatsHistorySnapshot()),
+        );
+        when(repository.getPhaseSnapshot()).thenAnswer(
+          (_) async => Success(createProfilePhaseSnapshot()),
         );
       },
       build: () => cubit,
@@ -76,11 +83,16 @@ void main() {
               completedAt: testProfileTestCompletedAt,
             ),
           ),
+          phaseSnapshot: ProfilePhaseSnapshot(
+            hasProgress: testProfileHasProgress,
+            currentPhaseName: testProfilePhaseName,
+          ),
         ),
       ],
       verify: (_) {
         verify(repository.getUser()).called(1);
         verify(repository.getStatsHistorySnapshot()).called(1);
+        verify(repository.getPhaseSnapshot()).called(1);
       },
     );
 
@@ -90,6 +102,9 @@ void main() {
         when(repository.getUser()).thenAnswer((_) async => const Success(updatedUser));
         when(repository.getStatsHistorySnapshot()).thenAnswer(
           (_) async => Success(createProfileStatsHistorySnapshot()),
+        );
+        when(repository.getPhaseSnapshot()).thenAnswer(
+          (_) async => Success(createProfilePhaseSnapshot()),
         );
       },
       build: () => cubit,
@@ -123,11 +138,16 @@ void main() {
               completedAt: testProfileTestCompletedAt,
             ),
           ),
+          phaseSnapshot: ProfilePhaseSnapshot(
+            hasProgress: testProfileHasProgress,
+            currentPhaseName: testProfilePhaseName,
+          ),
         ),
       ],
       verify: (_) {
         verify(repository.getUser()).called(1);
         verify(repository.getStatsHistorySnapshot()).called(1);
+        verify(repository.getPhaseSnapshot()).called(1);
       },
     );
 

--- a/test/features/profile/support/profile_dto_fixtures.dart
+++ b/test/features/profile/support/profile_dto_fixtures.dart
@@ -6,6 +6,7 @@ import 'package:moveup_flutter/features/profile/data/dto/profile_user_data_dto.d
 import 'package:moveup_flutter/features/profile/data/dto/profile_user_dto.dart';
 import 'package:moveup_flutter/features/profile/data/dto/profile_user_response_dto.dart';
 import 'package:moveup_flutter/features/profile/data/dto/profile_workout_history_item_dto.dart';
+import 'package:moveup_flutter/features/profile/domain/entities/profile_phase_snapshot.dart';
 import 'package:moveup_flutter/features/profile/domain/entities/profile_stats_history_snapshot.dart';
 
 const testProfileUserId = 1;
@@ -27,6 +28,9 @@ const testProfileTestAttemptId = 3;
 const testProfileTestId = 2;
 const testProfileTestTitle = 'Базовый тест';
 const testProfileTestCompletedAt = '2026-03-14 15:20:00';
+const testProfilePhaseId = 7;
+const testProfilePhaseName = 'A1';
+const testProfileHasProgress = true;
 
 /// Test fixture for a shared authenticated [User].
 User createProfileUser({
@@ -64,13 +68,33 @@ ProfileUserResponseDto createProfileUserResponseDto({
   ProfileSubscriptionsDto? subscriptions,
   ProfileWorkoutsDto? workouts,
   ProfileTestsDto? tests,
+  ProfilePhaseDto? phase,
 }) => ProfileUserResponseDto(
   data: ProfileUserDataDto(
     user: user ?? createProfileUserDto(),
     subscriptions: subscriptions,
     workouts: workouts,
     tests: tests,
+    phase: phase,
   ),
+);
+
+/// Test fixture for [ProfilePhaseDto].
+ProfilePhaseDto createProfilePhaseDto({
+  bool hasProgress = testProfileHasProgress,
+  ProfileCurrentPhaseDto? currentPhase,
+}) => ProfilePhaseDto(
+  hasProgress: hasProgress,
+  currentPhase: currentPhase ?? createProfileCurrentPhaseDto(),
+);
+
+/// Test fixture for [ProfileCurrentPhaseDto].
+ProfileCurrentPhaseDto createProfileCurrentPhaseDto({
+  int id = testProfilePhaseId,
+  String name = testProfilePhaseName,
+}) => ProfileCurrentPhaseDto(
+  id: id,
+  name: name,
 );
 
 /// Test fixture for [ProfileSubscriptionsDto].
@@ -176,6 +200,15 @@ ProfileStatsHistorySnapshot createProfileStatsHistorySnapshot({
         title: testProfileTestTitle,
         completedAt: testProfileTestCompletedAt,
       ),
+);
+
+/// Test fixture for [ProfilePhaseSnapshot].
+ProfilePhaseSnapshot createProfilePhaseSnapshot({
+  bool hasProgress = testProfileHasProgress,
+  String? currentPhaseName = testProfilePhaseName,
+}) => ProfilePhaseSnapshot(
+  hasProgress: hasProgress,
+  currentPhaseName: currentPhaseName,
 );
 
 /// Test fixture for Dio bad response exception.

--- a/test/features/profile/support/profile_statistics_dto_fixtures.dart
+++ b/test/features/profile/support/profile_statistics_dto_fixtures.dart
@@ -1,11 +1,13 @@
 import 'package:dio/dio.dart';
 import 'package:moveup_flutter/features/profile/data/dto/stats/frequency_response_dto.dart';
 import 'package:moveup_flutter/features/profile/data/dto/stats/profile_exercises_response_dto.dart';
+import 'package:moveup_flutter/features/profile/data/dto/stats/profile_statistics_overview_response_dto.dart';
 import 'package:moveup_flutter/features/profile/data/dto/stats/profile_workouts_response_dto.dart';
 import 'package:moveup_flutter/features/profile/data/dto/stats/trend_response_dto.dart';
 import 'package:moveup_flutter/features/profile/data/dto/stats/volume_response_dto.dart';
 import 'package:moveup_flutter/features/profile/domain/entities/profile_statistics/frequency_period.dart';
 import 'package:moveup_flutter/features/profile/domain/entities/profile_statistics/frequency_statistics_data.dart';
+import 'package:moveup_flutter/features/profile/domain/entities/profile_statistics/profile_current_phase_summary.dart';
 import 'package:moveup_flutter/features/profile/domain/entities/profile_statistics/profile_exercise_option.dart';
 import 'package:moveup_flutter/features/profile/domain/entities/profile_statistics/profile_workout_option.dart';
 import 'package:moveup_flutter/features/profile/domain/entities/profile_statistics/trend_statistics_data.dart';
@@ -24,6 +26,8 @@ const testTrendWorkoutId = 231;
 const testTrendWorkoutTitle = 'Силовая: Грудь + трицепс';
 const testTrendWorkoutCompletedFormatted = '18.03.2026 08:32';
 const testFrequencyLabel = 'Текущий месяц';
+const testProfileCurrentPhaseAveragePerWeek = 2.3;
+const testProfileCurrentPhaseWeeklyGoal = 4;
 
 const testProfileStatisticsVolumeData = VolumeStatisticsData(
   hasData: true,
@@ -96,6 +100,11 @@ const testProfileStatisticsFrequencyData = FrequencyStatisticsData(
       goal: 4,
     ),
   ],
+);
+
+const testProfileCurrentPhaseSummary = ProfileCurrentPhaseSummary(
+  averagePerWeek: testProfileCurrentPhaseAveragePerWeek,
+  weeklyGoal: testProfileCurrentPhaseWeeklyGoal,
 );
 
 const testProfileStatisticsYearFrequencyData = FrequencyStatisticsData(
@@ -267,6 +276,36 @@ FrequencyResponseDto createFrequencyResponseDto({
   FrequencyStatisticsDto? data,
 }) => FrequencyResponseDto(
   data: data ?? createFrequencyStatisticsDto(),
+);
+
+/// Test fixture for [ProfileStatisticsOverviewResponseDto].
+ProfileStatisticsOverviewResponseDto createProfileStatisticsOverviewResponseDto({
+  ProfileStatisticsOverviewDataDto? data,
+}) => ProfileStatisticsOverviewResponseDto(
+  data: data ?? createProfileStatisticsOverviewDataDto(),
+);
+
+/// Test fixture for [ProfileStatisticsOverviewDataDto].
+ProfileStatisticsOverviewDataDto createProfileStatisticsOverviewDataDto({
+  ProfileStatisticsOverviewFrequencyDto? frequency,
+}) => ProfileStatisticsOverviewDataDto(
+  frequency: frequency ?? createProfileStatisticsOverviewFrequencyDto(),
+);
+
+/// Test fixture for [ProfileStatisticsOverviewFrequencyDto].
+ProfileStatisticsOverviewFrequencyDto createProfileStatisticsOverviewFrequencyDto({
+  ProfileStatisticsOverviewFrequencySummaryDto? summary,
+}) => ProfileStatisticsOverviewFrequencyDto(
+  summary: summary ?? createProfileStatisticsOverviewFrequencySummaryDto(),
+);
+
+/// Test fixture for [ProfileStatisticsOverviewFrequencySummaryDto].
+ProfileStatisticsOverviewFrequencySummaryDto createProfileStatisticsOverviewFrequencySummaryDto({
+  double averagePerWeek = testProfileCurrentPhaseAveragePerWeek,
+  int weeklyGoal = testProfileCurrentPhaseWeeklyGoal,
+}) => ProfileStatisticsOverviewFrequencySummaryDto(
+  averagePerWeek: averagePerWeek,
+  weeklyGoal: weeklyGoal,
 );
 
 /// Test fixture for [FrequencyStatisticsDto].


### PR DESCRIPTION
## 🚀 Summary

Implemented the read-only `Current Phase` section for the authenticated `/profile` tab without introducing a standalone phase slice. The section now composes existing profile bootstrap data from `/api/profile` with aggregate frequency summary data from `/api/profile/statistics`, keeping ownership inside `ProfileUserCubit` and `ProfileStatisticsCubit`.

## ✨ Changes

- ✅ Extended the authenticated `/api/profile` bootstrap mapping with a focused `ProfilePhaseSnapshot`
- ✅ Updated `ProfileRepository` and `ProfileUserCubit` (+ unit tests for each one) so profile bootstrap now carries `phaseSnapshot` alongside `user` and `historySnapshot`
- ✅ Added aggregate statistics overview support in the existing profile statistics stack through `ProfileStatisticsApiClient.getOverview()`
- ✅ Added focused `ProfileCurrentPhaseSummary` mapping from `data.frequency.summary.average_per_week` and `data.frequency.summary.weekly_goal`
- ✅ Extended `ProfileStatisticsRepository`, `ProfileStatisticsState`, and `ProfileStatisticsCubit` with a separate current-phase-summary sub-flow and dedicated reload method (+ unit tests)
- ✅ Added `CurrentPhaseSectionWidget` below the statistics history block in `/profile`
- ✅ Added local loading, empty, and retry states for the current phase section without affecting the existing statistics card flow

## 🧪 Verification

- [x] `flutter analyze`
- [x] `flutter test test/features/profile`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added a "Current Phase" section to your profile displaying your active training phase, weekly training goals, and average trainings per week
* Empty state message appears when no active phase exists
* Error message displays if phase data fails to load, with option to retry

<!-- end of auto-generated comment: release notes by coderabbit.ai -->