### PR TITLE
feat(profile): add bottom profile actions with authenticated sign-out and legal links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Profile statistics section for the authenticated `/profile` tab, including dedicated statistics API client/repository, focused `/profile` history snapshot mapping, statistics Cubit/state flow, chart widgets, selectors, history dialog, and widget coverage for the integrated UI.
 - Profile current phase section for the authenticated `/profile` tab, reusing the bootstrap profile phase snapshot plus aggregate statistics frequency summary to render the read-only phase block without a standalone phase slice.
 - Introduce personal parameters section for the authenticated `/profile` tab, including canonical `user-parameters` read/update flow, editable profile form card, weekly-goal save support, and selective workouts overview refresh when goal, equipment, or level changes regenerate the personal plan.
+- Add profile bottom section for the authenticated `/profile` tab, including logout and delete-profile confirmation actions plus direct links to the bundled legal documents.
 
 ### Changed
 
@@ -37,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Profile statistics internals were reorganized into dedicated `profile/data/dto/stats` and `profile/presentation/widgets/stats` folders, while repository/cubit/widget tests were aligned with the new structure and shared fixtures.
 - Shared `OptionButton` now supports canonical `large` and `small` size presets, and the profile statistics plus history-tab controls use the compact 42px variant from the mockups.
 - Profile dialogs now support per-dialog content padding and optional barrier dismissal, allowing the statistics history modal to match the provided sheet behavior without affecting non-dismissible dialogs.
+- The debug route is now a static centered placeholder again and no longer owns a separate logout flow.
 
 ### Breaking
 

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -350,7 +350,7 @@ abstract final class AppStrings {
   }
 
   // Debug screen.
-  static const debugLogoutButton = 'Выйти';
+  static const debugScreenTitle = 'Debug Screen';
 
   /// Root tabs.
   static const testsTab = testsCatalogTitle;

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -74,6 +74,7 @@ abstract final class AppStrings {
   static const legalDataProcessingConsentTitle = 'Согласие на обработку персональных данных';
   static const legalPublicOfferTitle = 'Публичная оферта';
   static const legalDocumentLoadError = 'Не удалось загрузить документ.';
+  static const legalDataProcessingConsentProfileTitle = 'Пользовательское соглашение';
 
   // Feedback dialogs.
   static const feedbackErrorTitle = 'Что-то пошло не так';
@@ -276,6 +277,11 @@ abstract final class AppStrings {
   static const profileParametersWeeklyGoalInvalid =
       'Введите корректное количество тренировок в неделю';
   static const profileParametersWeeklyGoalRange = 'Допустимо от 1 до 7 тренировок в неделю';
+  static const profileBottomLogoutButton = 'Выйти';
+  static const profileBottomDeleteButton = 'Удалить профиль';
+  static const profileBottomLogoutTitle = 'Вы уверены, что хотите выйти?';
+  static const profileBottomDeleteTitle = 'Вы уверены, что хотите удалить профиль?';
+  static const profileBottomDeleteConfirm = 'Удалить';
   static const profileStatsTitle = 'Статистика тренировок пользователя';
   static const profileStatsHistoryButton = 'История';
   static const profileStatsVolumeMode = 'Объём';

--- a/lib/core/router/router.dart
+++ b/lib/core/router/router.dart
@@ -108,6 +108,7 @@ String? _redirectByAuth(
   final isSplashScreen = state.matchedLocation == AppRoutePaths.splashPath;
   final isAuthScreen = state.matchedLocation.startsWith(AppRoutePaths.authPrefix);
   final isFitnessStartScreen = state.matchedLocation.startsWith(AppRoutePaths.fitnessStartPrefix);
+  final isLegalDocument = state.matchedLocation == AppRoutePaths.legalDocumentPath;
   return authState.when(
     initial: () {
       if (isSplashScreen) return null;
@@ -122,7 +123,7 @@ String? _redirectByAuth(
       if (state.matchedLocation == AppRoutePaths.signUpPath) {
         return AppRoutePaths.fitnessStartQuizPath;
       }
-      if (state.matchedLocation == AppRoutePaths.legalDocumentPath) return null;
+      if (isLegalDocument) return null;
       if (isAuthScreen) return null;
       return AppRoutePaths.signInPath;
     },
@@ -146,7 +147,7 @@ String? _redirectByAuth(
           state.matchedLocation == AppRoutePaths.debugPath) {
         return null;
       }
-      if (state.matchedLocation == AppRoutePaths.legalDocumentPath) return null;
+      if (isLegalDocument) return null;
       if (_isAuthenticatedAllowedAuthPath(state.matchedLocation)) return null;
       if (isSplashScreen || isAuthScreen || isFitnessStartScreen) {
         return AppRoutePaths.workoutsPath;
@@ -158,7 +159,7 @@ String? _redirectByAuth(
       if (state.matchedLocation == AppRoutePaths.signUpPath) {
         return AppRoutePaths.fitnessStartQuizPath;
       }
-      if (state.matchedLocation == AppRoutePaths.legalDocumentPath) return null;
+      if (isLegalDocument) return null;
       if (isAuthScreen) return null;
       return AppRoutePaths.signInPath;
     },

--- a/lib/core/router/router.dart
+++ b/lib/core/router/router.dart
@@ -122,6 +122,7 @@ String? _redirectByAuth(
       if (state.matchedLocation == AppRoutePaths.signUpPath) {
         return AppRoutePaths.fitnessStartQuizPath;
       }
+      if (state.matchedLocation == AppRoutePaths.legalDocumentPath) return null;
       if (isAuthScreen) return null;
       return AppRoutePaths.signInPath;
     },
@@ -145,6 +146,7 @@ String? _redirectByAuth(
           state.matchedLocation == AppRoutePaths.debugPath) {
         return null;
       }
+      if (state.matchedLocation == AppRoutePaths.legalDocumentPath) return null;
       if (_isAuthenticatedAllowedAuthPath(state.matchedLocation)) return null;
       if (isSplashScreen || isAuthScreen || isFitnessStartScreen) {
         return AppRoutePaths.workoutsPath;
@@ -156,6 +158,7 @@ String? _redirectByAuth(
       if (state.matchedLocation == AppRoutePaths.signUpPath) {
         return AppRoutePaths.fitnessStartQuizPath;
       }
+      if (state.matchedLocation == AppRoutePaths.legalDocumentPath) return null;
       if (isAuthScreen) return null;
       return AppRoutePaths.signInPath;
     },

--- a/lib/core/router/router_paths.dart
+++ b/lib/core/router/router_paths.dart
@@ -31,7 +31,7 @@ abstract class AppRoutePaths {
   static const signUpPath = '$authPrefix/sign-up';
 
   /// Route path for the legal-document page.
-  static const legalDocumentPath = '$authPrefix/legal-document';
+  static const legalDocumentPath = '/legal-document';
 
   /// Route path for the forgot-password page.
   static const forgotPasswordPath = '$authPrefix/forgot-password';

--- a/lib/features/auth/presentation/cubits/auth_session_cubit.dart
+++ b/lib/features/auth/presentation/cubits/auth_session_cubit.dart
@@ -273,12 +273,7 @@ final class AuthSessionCubit extends Cubit<AuthSessionState> {
 
   /// Fully signs out the authenticated user from the current device.
   Future<void> signOut() async {
-    try {
-      await _tokenStorage.deleteAccessToken();
-    } catch (e, s) {
-      _logger.e('Failed to clear access token during sign-out.', e, s);
-    }
-
+    await _clearTokenSafely();
     await clearSession();
   }
 }

--- a/lib/features/auth/presentation/cubits/auth_session_cubit.dart
+++ b/lib/features/auth/presentation/cubits/auth_session_cubit.dart
@@ -270,4 +270,15 @@ final class AuthSessionCubit extends Cubit<AuthSessionState> {
       emit(const AuthSessionState.unauthenticated());
     }
   }
+
+  /// Fully signs out the authenticated user from the current device.
+  Future<void> signOut() async {
+    try {
+      await _tokenStorage.deleteAccessToken();
+    } catch (e, s) {
+      _logger.e('Failed to clear access token during sign-out.', e, s);
+    }
+
+    await clearSession();
+  }
 }

--- a/lib/features/debug/presentation/debug_screen.dart
+++ b/lib/features/debug/presentation/debug_screen.dart
@@ -1,13 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../../core/constants/app_strings.dart';
-import '../../../core/di/di.dart';
-import '../../../uikit/dialogs/app_feedback_dialog.dart';
-import '../../auth/domain/repositories/auth_repository.dart';
-import '../../auth/presentation/cubits/auth_session_cubit.dart';
-import '../../auth/presentation/cubits/logout_cubit.dart';
-import 'dart:async';
 
 /// A screen for debugging purposes.
 class DebugScreen extends StatelessWidget {
@@ -16,50 +9,9 @@ class DebugScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MultiBlocProvider(
-      providers: [
-        BlocProvider.value(value: di<AuthSessionCubit>()),
-        BlocProvider(
-          create: (context) => LogoutCubit(di<AuthRepository>()),
-        ),
-      ],
-      child: BlocListener<LogoutCubit, LogoutState>(
-        listener: (context, state) {
-          state.whenOrNull(
-            succeed: () => unawaited(context.read<AuthSessionCubit>().signOut()),
-            failed: (failure) {
-              if (failure.message.isNotEmpty) {
-                showAppFeedbackDialog(
-                  context,
-                  title: AppStrings.feedbackErrorTitle,
-                  message: failure.message,
-                );
-              }
-            },
-          );
-        },
-        child: Scaffold(
-          body: Center(
-            child: BlocBuilder<LogoutCubit, LogoutState>(
-              builder: (context, state) {
-                final isInProgress = state.maybeWhen(
-                  inProgress: () => true,
-                  orElse: () => false,
-                );
-                return FilledButton(
-                  onPressed: isInProgress ? null : () => context.read<LogoutCubit>().logout(),
-                  child: isInProgress
-                      ? const SizedBox(
-                          height: 20,
-                          width: 20,
-                          child: CircularProgressIndicator.adaptive(),
-                        )
-                      : const Text(AppStrings.debugLogoutButton),
-                );
-              },
-            ),
-          ),
-        ),
+    return const Scaffold(
+      body: Center(
+        child: Text(AppStrings.debugScreenTitle),
       ),
     );
   }

--- a/lib/features/debug/presentation/debug_screen.dart
+++ b/lib/features/debug/presentation/debug_screen.dart
@@ -26,7 +26,7 @@ class DebugScreen extends StatelessWidget {
       child: BlocListener<LogoutCubit, LogoutState>(
         listener: (context, state) {
           state.whenOrNull(
-            succeed: () => unawaited(context.read<AuthSessionCubit>().clearSession()),
+            succeed: () => unawaited(context.read<AuthSessionCubit>().signOut()),
             failed: (failure) {
               if (failure.message.isNotEmpty) {
                 showAppFeedbackDialog(

--- a/lib/features/profile/data/remote/profile_api_client.dart
+++ b/lib/features/profile/data/remote/profile_api_client.dart
@@ -22,6 +22,10 @@ abstract class ProfileApiClient {
   @PUT(ApiPaths.profile)
   Future<void> updateProfile(@Body() UpdateProfileRequestDto request);
 
+  /// Deletes the authenticated user profile.
+  @DELETE(ApiPaths.profile)
+  Future<void> deleteProfile();
+
   /// Changes the authenticated user password.
   @POST(ApiPaths.profileChangePassword)
   Future<void> changePassword(@Body() ChangePasswordRequestDto request);

--- a/lib/features/profile/data/repositories/profile_repository_impl.dart
+++ b/lib/features/profile/data/repositories/profile_repository_impl.dart
@@ -205,4 +205,20 @@ final class ProfileRepositoryImpl implements ProfileRepository {
       );
     }
   }
+
+  @override
+  Future<Result<void, ProfileFailure>> deleteProfile() async {
+    try {
+      await _apiClient.deleteProfile();
+      return const Result.success(null);
+    } on DioException catch (e) {
+      final networkFailure = e.toNetworkFailure();
+      return Result.failure(networkFailure.toProfileFailure());
+    } catch (e, s) {
+      _logger.e('DeleteProfile failed with unexpected error', e, s);
+      return Result.failure(
+        UnknownProfileFailure(parentException: e, stackTrace: s),
+      );
+    }
+  }
 }

--- a/lib/features/profile/domain/repositories/profile_repository.dart
+++ b/lib/features/profile/domain/repositories/profile_repository.dart
@@ -33,4 +33,7 @@ abstract interface class ProfileRepository {
     required String newPassword,
     required String newPasswordConfirmation,
   });
+
+  /// Deletes the current authenticated profile.
+  Future<Result<void, ProfileFailure>> deleteProfile();
 }

--- a/lib/features/profile/presentation/cubits/delete_profile_cubit.dart
+++ b/lib/features/profile/presentation/cubits/delete_profile_cubit.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../../../../core/failures/feature/profile/profile_failure.dart';
+import '../../../../../core/result/result.dart';
+import '../../domain/repositories/profile_repository.dart';
+
+part 'delete_profile_cubit.freezed.dart';
+part 'delete_profile_state.dart';
+
+/// Cubit that manages the delete-profile flow.
+final class DeleteProfileCubit extends Cubit<DeleteProfileState> {
+  final ProfileRepository _repository;
+
+  /// Creates an instance of [DeleteProfileCubit].
+  DeleteProfileCubit(this._repository) : super(const DeleteProfileState.initial());
+
+  /// Attempts to delete the current authenticated profile.
+  Future<void> deleteProfile() async {
+    final isInProgress = state.maybeWhen(
+      inProgress: () => true,
+      orElse: () => false,
+    );
+    if (isInProgress) return;
+
+    emit(const DeleteProfileState.inProgress());
+
+    final result = await _repository.deleteProfile();
+    if (isClosed) return;
+
+    switch (result) {
+      case Success():
+        emit(const DeleteProfileState.succeed());
+      case Failure(:final error):
+        emit(DeleteProfileState.failed(error));
+    }
+  }
+}

--- a/lib/features/profile/presentation/cubits/delete_profile_state.dart
+++ b/lib/features/profile/presentation/cubits/delete_profile_state.dart
@@ -1,0 +1,17 @@
+part of 'delete_profile_cubit.dart';
+
+/// States for [DeleteProfileCubit].
+@freezed
+class DeleteProfileState with _$DeleteProfileState {
+  /// Initial idle state.
+  const factory DeleteProfileState.initial() = _Initial;
+
+  /// Delete request is in progress.
+  const factory DeleteProfileState.inProgress() = _InProgress;
+
+  /// Profile deletion succeeded.
+  const factory DeleteProfileState.succeed() = _Succeed;
+
+  /// Profile deletion failed.
+  const factory DeleteProfileState.failed(ProfileFailure failure) = _Failed;
+}

--- a/lib/features/profile/presentation/pages/profile_page.dart
+++ b/lib/features/profile/presentation/pages/profile_page.dart
@@ -8,7 +8,6 @@ import '../../../../../core/constants/app_assets.dart';
 import '../../../../../core/constants/app_strings.dart';
 import '../../../../../core/router/router_paths.dart';
 import '../../../../../uikit/buttons/main_button.dart';
-import '../../../../../uikit/buttons/secondary_button.dart';
 import '../../../../../uikit/images/svg_picture_widget.dart';
 import '../../../../../uikit/themes/colors/app_color_theme.dart';
 import '../../../../../uikit/themes/text/app_text_theme.dart';
@@ -18,13 +17,9 @@ import '../cubits/profile_parameters_cubit.dart';
 import '../cubits/profile_statistics_cubit.dart';
 import '../cubits/profile_user_cubit.dart';
 import '../widgets/change_password_dialog.dart';
-import '../widgets/current_phase_section_widget.dart';
 import '../widgets/edit_profile_dialog.dart';
 import '../widgets/profile_bottom_section_widget.dart';
-import '../widgets/profile_parameters_section_widget.dart';
 import '../widgets/stats/profile_history_dialog.dart';
-import '../widgets/stats/stats_section_widget.dart';
-import '../widgets/user_section_widget.dart';
 
 /// Authenticated profile page with the user section only.
 class ProfilePage extends StatelessWidget {
@@ -86,48 +81,48 @@ class ProfilePage extends StatelessWidget {
         child: BlocBuilder<ProfileUserCubit, ProfileUserState>(
           builder: (context, state) {
             final user = state.user;
-            if (user == null) {
-              return _ProfileUserFallbackState(
-                isLoading: state.isLoading,
-                onRetryPressed: () => context.read<ProfileUserCubit>().refresh(),
-              );
-            }
-            return SingleChildScrollView(
-              padding: const EdgeInsets.fromLTRB(24, 28, 24, 132),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  Text(
-                    AppStrings.profileGreeting(user.name),
-                    style: textTheme.bodyMedium.copyWith(
-                      fontSize: 18,
-                      height: 27 / 18,
-                      fontWeight: FontWeight.w500,
-                      color: colorTheme.onSurface,
-                    ),
-                  ),
-                  const SizedBox(height: 24),
-                  UserSectionWidget(
-                    user: user,
-                    onEditPressed: () => _openEditProfileDialog(context, user),
-                    onChangePasswordPressed: () => _openChangePasswordDialog(context),
-                  ),
-                  const SizedBox(height: 36),
-                  const StatsSectionWidget(),
-                  const SizedBox(height: 20),
-                  SecondaryButton(
-                    onPressed: () => _openHistoryDialog(context),
-                    child: const Text(AppStrings.profileStatsHistoryButton),
-                  ),
-                  const SizedBox(height: 36),
-                  const CurrentPhaseSectionWidget(),
-                  const SizedBox(height: 36),
-                  const ProfileParametersSectionWidget(),
-                  const SizedBox(height: 36),
-                  const ProfileBottomSectionWidget(),
-                ],
-              ),
+            // if (user == null) {
+            return _ProfileUserFallbackState(
+              isLoading: state.isLoading,
+              onRetryPressed: () => context.read<ProfileUserCubit>().refresh(),
             );
+            // }
+            // return SingleChildScrollView(
+            //   padding: const EdgeInsets.fromLTRB(24, 28, 24, 132),
+            //   child: Column(
+            //     crossAxisAlignment: CrossAxisAlignment.stretch,
+            //     children: [
+            //       Text(
+            //         AppStrings.profileGreeting(user.name),
+            //         style: textTheme.bodyMedium.copyWith(
+            //           fontSize: 18,
+            //           height: 27 / 18,
+            //           fontWeight: FontWeight.w500,
+            //           color: colorTheme.onSurface,
+            //         ),
+            //       ),
+            //       const SizedBox(height: 24),
+            //       UserSectionWidget(
+            //         user: user,
+            //         onEditPressed: () => _openEditProfileDialog(context, user),
+            //         onChangePasswordPressed: () => _openChangePasswordDialog(context),
+            //       ),
+            //       const SizedBox(height: 36),
+            //       const StatsSectionWidget(),
+            //       const SizedBox(height: 20),
+            //       SecondaryButton(
+            //         onPressed: () => _openHistoryDialog(context),
+            //         child: const Text(AppStrings.profileStatsHistoryButton),
+            //       ),
+            //       const SizedBox(height: 36),
+            //       const CurrentPhaseSectionWidget(),
+            //       const SizedBox(height: 36),
+            //       const ProfileParametersSectionWidget(),
+            //       const SizedBox(height: 36),
+            //       const ProfileBottomSectionWidget(),
+            //     ],
+            //   ),
+            // );
           },
         ),
       ),
@@ -148,6 +143,7 @@ final class _ProfileUserFallbackState extends StatelessWidget {
   Widget build(BuildContext context) {
     final textTheme = AppTextTheme.of(context);
     final colorTheme = AppColorTheme.of(context);
+    const contentPadding = EdgeInsets.fromLTRB(24, 28, 24, 132);
 
     if (isLoading) {
       return const Center(
@@ -158,36 +154,47 @@ final class _ProfileUserFallbackState extends StatelessWidget {
       );
     }
 
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(24, 28, 24, 132),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Expanded(
-              child: Center(
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return SingleChildScrollView(
+          padding: contentPadding,
+          child: ConstrainedBox(
+            constraints: BoxConstraints(
+              minHeight: constraints.maxHeight - contentPadding.vertical,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Center(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        AppStrings.profileLoadFailed,
+                        textAlign: TextAlign.center,
+                        style: textTheme.bodyMedium.copyWith(color: colorTheme.onSurface),
+                      ),
+                      const SizedBox(height: 16),
+                      MainButton(
+                        onPressed: onRetryPressed,
+                        child: const Text(AppStrings.retryButton),
+                      ),
+                    ],
+                  ),
+                ),
+                const Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
-                    Text(
-                      AppStrings.profileLoadFailed,
-                      textAlign: TextAlign.center,
-                      style: textTheme.bodyMedium.copyWith(color: colorTheme.onSurface),
-                    ),
-                    const SizedBox(height: 16),
-                    MainButton(
-                      onPressed: onRetryPressed,
-                      child: const Text(AppStrings.retryButton),
-                    ),
+                    SizedBox(height: 16),
+                    ProfileBottomSectionWidget(),
                   ],
                 ),
-              ),
+              ],
             ),
-            const SizedBox(height: 16),
-            const ProfileBottomSectionWidget(),
-          ],
-        ),
-      ),
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/features/profile/presentation/pages/profile_page.dart
+++ b/lib/features/profile/presentation/pages/profile_page.dart
@@ -19,8 +19,8 @@ import '../cubits/profile_statistics_cubit.dart';
 import '../cubits/profile_user_cubit.dart';
 import '../widgets/change_password_dialog.dart';
 import '../widgets/current_phase_section_widget.dart';
-import '../widgets/profile_bottom_section_widget.dart';
 import '../widgets/edit_profile_dialog.dart';
+import '../widgets/profile_bottom_section_widget.dart';
 import '../widgets/profile_parameters_section_widget.dart';
 import '../widgets/stats/profile_history_dialog.dart';
 import '../widgets/stats/stats_section_widget.dart';
@@ -160,20 +160,31 @@ final class _ProfileUserFallbackState extends StatelessWidget {
 
     return Center(
       child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 24),
+        padding: const EdgeInsets.fromLTRB(24, 28, 24, 132),
         child: Column(
-          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            Text(
-              AppStrings.profileLoadFailed,
-              textAlign: TextAlign.center,
-              style: textTheme.bodyMedium.copyWith(color: colorTheme.onSurface),
+            Expanded(
+              child: Center(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      AppStrings.profileLoadFailed,
+                      textAlign: TextAlign.center,
+                      style: textTheme.bodyMedium.copyWith(color: colorTheme.onSurface),
+                    ),
+                    const SizedBox(height: 16),
+                    MainButton(
+                      onPressed: onRetryPressed,
+                      child: const Text(AppStrings.retryButton),
+                    ),
+                  ],
+                ),
+              ),
             ),
             const SizedBox(height: 16),
-            MainButton(
-              onPressed: onRetryPressed,
-              child: const Text(AppStrings.retryButton),
-            ),
+            const ProfileBottomSectionWidget(),
           ],
         ),
       ),

--- a/lib/features/profile/presentation/pages/profile_page.dart
+++ b/lib/features/profile/presentation/pages/profile_page.dart
@@ -19,6 +19,7 @@ import '../cubits/profile_statistics_cubit.dart';
 import '../cubits/profile_user_cubit.dart';
 import '../widgets/change_password_dialog.dart';
 import '../widgets/current_phase_section_widget.dart';
+import '../widgets/profile_bottom_section_widget.dart';
 import '../widgets/edit_profile_dialog.dart';
 import '../widgets/profile_parameters_section_widget.dart';
 import '../widgets/stats/profile_history_dialog.dart';
@@ -122,6 +123,8 @@ class ProfilePage extends StatelessWidget {
                   const CurrentPhaseSectionWidget(),
                   const SizedBox(height: 36),
                   const ProfileParametersSectionWidget(),
+                  const SizedBox(height: 36),
+                  const ProfileBottomSectionWidget(),
                 ],
               ),
             );

--- a/lib/features/profile/presentation/pages/profile_page.dart
+++ b/lib/features/profile/presentation/pages/profile_page.dart
@@ -8,6 +8,7 @@ import '../../../../../core/constants/app_assets.dart';
 import '../../../../../core/constants/app_strings.dart';
 import '../../../../../core/router/router_paths.dart';
 import '../../../../../uikit/buttons/main_button.dart';
+import '../../../../../uikit/buttons/secondary_button.dart';
 import '../../../../../uikit/images/svg_picture_widget.dart';
 import '../../../../../uikit/themes/colors/app_color_theme.dart';
 import '../../../../../uikit/themes/text/app_text_theme.dart';
@@ -17,9 +18,13 @@ import '../cubits/profile_parameters_cubit.dart';
 import '../cubits/profile_statistics_cubit.dart';
 import '../cubits/profile_user_cubit.dart';
 import '../widgets/change_password_dialog.dart';
+import '../widgets/current_phase_section_widget.dart';
 import '../widgets/edit_profile_dialog.dart';
 import '../widgets/profile_bottom_section_widget.dart';
+import '../widgets/profile_parameters_section_widget.dart';
 import '../widgets/stats/profile_history_dialog.dart';
+import '../widgets/stats/stats_section_widget.dart';
+import '../widgets/user_section_widget.dart';
 
 /// Authenticated profile page with the user section only.
 class ProfilePage extends StatelessWidget {
@@ -81,48 +86,48 @@ class ProfilePage extends StatelessWidget {
         child: BlocBuilder<ProfileUserCubit, ProfileUserState>(
           builder: (context, state) {
             final user = state.user;
-            // if (user == null) {
-            return _ProfileUserFallbackState(
-              isLoading: state.isLoading,
-              onRetryPressed: () => context.read<ProfileUserCubit>().refresh(),
+            if (user == null) {
+              return _ProfileUserFallbackState(
+                isLoading: state.isLoading,
+                onRetryPressed: () => context.read<ProfileUserCubit>().refresh(),
+              );
+            }
+            return SingleChildScrollView(
+              padding: const EdgeInsets.fromLTRB(24, 28, 24, 132),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Text(
+                    AppStrings.profileGreeting(user.name),
+                    style: textTheme.bodyMedium.copyWith(
+                      fontSize: 18,
+                      height: 27 / 18,
+                      fontWeight: FontWeight.w500,
+                      color: colorTheme.onSurface,
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  UserSectionWidget(
+                    user: user,
+                    onEditPressed: () => _openEditProfileDialog(context, user),
+                    onChangePasswordPressed: () => _openChangePasswordDialog(context),
+                  ),
+                  const SizedBox(height: 36),
+                  const StatsSectionWidget(),
+                  const SizedBox(height: 20),
+                  SecondaryButton(
+                    onPressed: () => _openHistoryDialog(context),
+                    child: const Text(AppStrings.profileStatsHistoryButton),
+                  ),
+                  const SizedBox(height: 36),
+                  const CurrentPhaseSectionWidget(),
+                  const SizedBox(height: 36),
+                  const ProfileParametersSectionWidget(),
+                  const SizedBox(height: 36),
+                  const ProfileBottomSectionWidget(),
+                ],
+              ),
             );
-            // }
-            // return SingleChildScrollView(
-            //   padding: const EdgeInsets.fromLTRB(24, 28, 24, 132),
-            //   child: Column(
-            //     crossAxisAlignment: CrossAxisAlignment.stretch,
-            //     children: [
-            //       Text(
-            //         AppStrings.profileGreeting(user.name),
-            //         style: textTheme.bodyMedium.copyWith(
-            //           fontSize: 18,
-            //           height: 27 / 18,
-            //           fontWeight: FontWeight.w500,
-            //           color: colorTheme.onSurface,
-            //         ),
-            //       ),
-            //       const SizedBox(height: 24),
-            //       UserSectionWidget(
-            //         user: user,
-            //         onEditPressed: () => _openEditProfileDialog(context, user),
-            //         onChangePasswordPressed: () => _openChangePasswordDialog(context),
-            //       ),
-            //       const SizedBox(height: 36),
-            //       const StatsSectionWidget(),
-            //       const SizedBox(height: 20),
-            //       SecondaryButton(
-            //         onPressed: () => _openHistoryDialog(context),
-            //         child: const Text(AppStrings.profileStatsHistoryButton),
-            //       ),
-            //       const SizedBox(height: 36),
-            //       const CurrentPhaseSectionWidget(),
-            //       const SizedBox(height: 36),
-            //       const ProfileParametersSectionWidget(),
-            //       const SizedBox(height: 36),
-            //       const ProfileBottomSectionWidget(),
-            //     ],
-            //   ),
-            // );
           },
         ),
       ),

--- a/lib/features/profile/presentation/pages/profile_page_builder.dart
+++ b/lib/features/profile/presentation/pages/profile_page_builder.dart
@@ -3,10 +3,13 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../../../../core/di/di.dart';
 import '../../../auth/domain/entities/user.dart';
+import '../../../auth/domain/repositories/auth_repository.dart';
 import '../../../auth/presentation/cubits/auth_session_cubit.dart';
+import '../../../auth/presentation/cubits/logout_cubit.dart';
 import '../../domain/repositories/profile_parameters_repository.dart';
 import '../../domain/repositories/profile_repository.dart';
 import '../../domain/repositories/profile_statistics_repository.dart';
+import '../cubits/delete_profile_cubit.dart';
 import '../cubits/profile_parameters_cubit.dart';
 import '../cubits/profile_statistics_cubit.dart';
 import '../cubits/profile_user_cubit.dart';
@@ -42,6 +45,12 @@ class ProfilePageBuilder extends StatelessWidget {
           create: (_) => ProfileParametersCubit(
             di<ProfileParametersRepository>(),
           )..loadInitial(),
+        ),
+        BlocProvider(
+          create: (_) => LogoutCubit(di<AuthRepository>()),
+        ),
+        BlocProvider(
+          create: (_) => DeleteProfileCubit(di<ProfileRepository>()),
         ),
       ],
       child: const ProfilePage(),

--- a/lib/features/profile/presentation/widgets/profile_bottom_section_widget.dart
+++ b/lib/features/profile/presentation/widgets/profile_bottom_section_widget.dart
@@ -1,0 +1,248 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../../core/constants/app_strings.dart';
+import '../../../../../core/router/router_paths.dart';
+import '../../../../../uikit/buttons/button_state.dart';
+import '../../../../../uikit/buttons/main_button.dart';
+import '../../../../../uikit/buttons/secondary_button.dart';
+import '../../../../../uikit/dialogs/app_action_dialog.dart';
+import '../../../../../uikit/dialogs/app_feedback_dialog.dart';
+import '../../../../../uikit/themes/colors/app_color_theme.dart';
+import '../../../../../uikit/themes/text/app_text_theme.dart';
+import '../../../auth/presentation/cubits/auth_session_cubit.dart';
+import '../../../auth/presentation/cubits/logout_cubit.dart';
+import '../../../auth/presentation/pages/legal_document_type.dart';
+import '../cubits/delete_profile_cubit.dart';
+
+/// Bottom profile section with logout/delete actions and legal links.
+class ProfileBottomSectionWidget extends StatefulWidget {
+  /// Creates an instance of [ProfileBottomSectionWidget].
+  const ProfileBottomSectionWidget({super.key});
+
+  @override
+  State<ProfileBottomSectionWidget> createState() => _ProfileBottomSectionWidgetState();
+}
+
+class _ProfileBottomSectionWidgetState extends State<ProfileBottomSectionWidget> {
+  bool _isLogoutDialogOpen = false;
+  bool _isDeleteDialogOpen = false;
+
+  Future<void> _openLogoutDialog() async {
+    if (_isLogoutDialogOpen) return;
+    _isLogoutDialogOpen = true;
+    final logoutCubit = context.read<LogoutCubit>();
+    await showAppActionDialog(
+      context,
+      title: AppStrings.profileBottomLogoutTitle,
+      primaryAction: BlocProvider.value(
+        value: logoutCubit,
+        child: BlocBuilder<LogoutCubit, LogoutState>(
+          builder: (context, state) {
+            final isInProgress = state.maybeWhen(
+              inProgress: () => true,
+              orElse: () => false,
+            );
+            return MainButton(
+              state: isInProgress ? ButtonState.loading : ButtonState.enabled,
+              onPressed: () => context.read<LogoutCubit>().logout(),
+              child: const Text(AppStrings.profileBottomLogoutButton),
+            );
+          },
+        ),
+      ),
+      secondaryAction: BlocProvider.value(
+        value: logoutCubit,
+        child: BlocBuilder<LogoutCubit, LogoutState>(
+          builder: (context, state) {
+            final isInProgress = state.maybeWhen(
+              inProgress: () => true,
+              orElse: () => false,
+            );
+            return SecondaryButton(
+              state: isInProgress ? ButtonState.disabled : ButtonState.enabled,
+              onPressed: _closeActiveDialog,
+              child: const Text(AppStrings.profileCancelButton),
+            );
+          },
+        ),
+      ),
+    );
+    _isLogoutDialogOpen = false;
+  }
+
+  Future<void> _openDeleteDialog() async {
+    if (_isDeleteDialogOpen) return;
+    _isDeleteDialogOpen = true;
+    final deleteProfileCubit = context.read<DeleteProfileCubit>();
+    await showAppActionDialog(
+      context,
+      title: AppStrings.profileBottomDeleteTitle,
+      primaryAction: BlocProvider.value(
+        value: deleteProfileCubit,
+        child: BlocBuilder<DeleteProfileCubit, DeleteProfileState>(
+          builder: (context, state) {
+            final isInProgress = state.maybeWhen(
+              inProgress: () => true,
+              orElse: () => false,
+            );
+            return MainButton(
+              state: isInProgress ? ButtonState.loading : ButtonState.enabled,
+              onPressed: () => context.read<DeleteProfileCubit>().deleteProfile(),
+              child: const Text(AppStrings.profileBottomDeleteConfirm),
+            );
+          },
+        ),
+      ),
+      secondaryAction: BlocProvider.value(
+        value: deleteProfileCubit,
+        child: BlocBuilder<DeleteProfileCubit, DeleteProfileState>(
+          builder: (context, state) {
+            final isInProgress = state.maybeWhen(
+              inProgress: () => true,
+              orElse: () => false,
+            );
+            return SecondaryButton(
+              state: isInProgress ? ButtonState.disabled : ButtonState.enabled,
+              onPressed: _closeActiveDialog,
+              child: const Text(AppStrings.profileCancelButton),
+            );
+          },
+        ),
+      ),
+    );
+    _isDeleteDialogOpen = false;
+  }
+
+  void _closeActiveDialog() {
+    final navigator = Navigator.of(context, rootNavigator: true);
+    if (!navigator.canPop()) return;
+    navigator.pop();
+  }
+
+  void _openLegalDocument(LegalDocumentType type) =>
+      unawaited(context.push(AppRoutePaths.legalDocumentPath, extra: type));
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiBlocListener(
+      listeners: [
+        BlocListener<LogoutCubit, LogoutState>(
+          listener: (context, state) {
+            state.whenOrNull(
+              succeed: () {
+                _closeActiveDialog();
+                unawaited(context.read<AuthSessionCubit>().signOut());
+              },
+              failed: (failure) {
+                _closeActiveDialog();
+                if (failure.message.isEmpty) return;
+                unawaited(
+                  showAppFeedbackDialog(
+                    context,
+                    title: AppStrings.feedbackErrorTitle,
+                    message: failure.message,
+                  ),
+                );
+              },
+            );
+          },
+        ),
+        BlocListener<DeleteProfileCubit, DeleteProfileState>(
+          listener: (context, state) {
+            state.whenOrNull(
+              succeed: () {
+                _closeActiveDialog();
+                unawaited(context.read<AuthSessionCubit>().signOut());
+              },
+              failed: (failure) {
+                _closeActiveDialog();
+                if (failure.message.isEmpty) return;
+                unawaited(
+                  showAppFeedbackDialog(
+                    context,
+                    title: AppStrings.feedbackErrorTitle,
+                    message: failure.message,
+                  ),
+                );
+              },
+            );
+          },
+        ),
+      ],
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          MainButton(
+            onPressed: _openLogoutDialog,
+            child: const Text(AppStrings.profileBottomLogoutButton),
+          ),
+          const SizedBox(height: 12),
+          SecondaryButton(
+            onPressed: _openDeleteDialog,
+            child: const Text(AppStrings.profileBottomDeleteButton),
+          ),
+          const SizedBox(height: 36),
+          _LegalLink(
+            label: AppStrings.legalDataProcessingConsentProfileTitle,
+            onPressed: () => _openLegalDocument(LegalDocumentType.dataProcessingConsent),
+          ),
+          const SizedBox(height: 6),
+          _LegalLink(
+            label: AppStrings.legalPublicOfferTitle,
+            onPressed: () => _openLegalDocument(LegalDocumentType.publicOffer),
+          ),
+          const SizedBox(height: 6),
+          _LegalLink(
+            label: AppStrings.legalPrivacyPolicyTitle,
+            onPressed: () => _openLegalDocument(LegalDocumentType.privacyPolicy),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+final class _LegalLink extends StatelessWidget {
+  final String label;
+  final VoidCallback onPressed;
+
+  const _LegalLink({
+    required this.label,
+    required this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorTheme = AppColorTheme.of(context);
+    final textTheme = AppTextTheme.of(context);
+
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: TextButton(
+        onPressed: onPressed,
+        style: ButtonStyle(
+          padding: const WidgetStatePropertyAll(EdgeInsets.zero),
+          minimumSize: const WidgetStatePropertyAll(Size.zero),
+          tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+          overlayColor: const WidgetStatePropertyAll(Colors.transparent),
+          foregroundColor: WidgetStateProperty.resolveWith((states) {
+            if (states.contains(WidgetState.disabled)) {
+              return colorTheme.disabled;
+            }
+            return colorTheme.outline;
+          }),
+          textStyle: WidgetStatePropertyAll(textTheme.body),
+        ),
+        child: Text(
+          label,
+          textAlign: TextAlign.start,
+          style: textTheme.body,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/profile/presentation/widgets/profile_bottom_section_widget.dart
+++ b/lib/features/profile/presentation/widgets/profile_bottom_section_widget.dart
@@ -35,91 +35,105 @@ class _ProfileBottomSectionWidgetState extends State<ProfileBottomSectionWidget>
     if (_isLogoutDialogOpen) return;
     _isLogoutDialogOpen = true;
     final logoutCubit = context.read<LogoutCubit>();
-    await showAppActionDialog(
-      context,
-      title: AppStrings.profileBottomLogoutTitle,
-      primaryAction: BlocProvider.value(
-        value: logoutCubit,
-        child: BlocBuilder<LogoutCubit, LogoutState>(
-          builder: (context, state) {
-            final isInProgress = state.maybeWhen(
-              inProgress: () => true,
-              orElse: () => false,
-            );
-            return MainButton(
-              state: isInProgress ? ButtonState.loading : ButtonState.enabled,
-              onPressed: () => context.read<LogoutCubit>().logout(),
-              child: const Text(AppStrings.profileBottomLogoutButton),
-            );
-          },
+    try {
+      await showAppActionDialog(
+        context,
+        title: AppStrings.profileBottomLogoutTitle,
+        primaryAction: BlocProvider.value(
+          value: logoutCubit,
+          child: BlocBuilder<LogoutCubit, LogoutState>(
+            builder: (context, state) {
+              final isInProgress = state.maybeWhen(
+                inProgress: () => true,
+                orElse: () => false,
+              );
+              return MainButton(
+                state: isInProgress ? ButtonState.loading : ButtonState.enabled,
+                onPressed: () => context.read<LogoutCubit>().logout(),
+                child: const Text(AppStrings.profileBottomLogoutButton),
+              );
+            },
+          ),
         ),
-      ),
-      secondaryAction: BlocProvider.value(
-        value: logoutCubit,
-        child: BlocBuilder<LogoutCubit, LogoutState>(
-          builder: (context, state) {
-            final isInProgress = state.maybeWhen(
-              inProgress: () => true,
-              orElse: () => false,
-            );
-            return SecondaryButton(
-              state: isInProgress ? ButtonState.disabled : ButtonState.enabled,
-              onPressed: _closeActiveDialog,
-              child: const Text(AppStrings.profileCancelButton),
-            );
-          },
+        secondaryAction: BlocProvider.value(
+          value: logoutCubit,
+          child: BlocBuilder<LogoutCubit, LogoutState>(
+            builder: (context, state) {
+              final isInProgress = state.maybeWhen(
+                inProgress: () => true,
+                orElse: () => false,
+              );
+              return SecondaryButton(
+                state: isInProgress ? ButtonState.disabled : ButtonState.enabled,
+                onPressed: _closeActiveDialog,
+                child: const Text(AppStrings.profileCancelButton),
+              );
+            },
+          ),
         ),
-      ),
-    );
-    _isLogoutDialogOpen = false;
+      );
+    } finally {
+      _isLogoutDialogOpen = false;
+    }
   }
 
   Future<void> _openDeleteDialog() async {
     if (_isDeleteDialogOpen) return;
     _isDeleteDialogOpen = true;
     final deleteProfileCubit = context.read<DeleteProfileCubit>();
-    await showAppActionDialog(
-      context,
-      title: AppStrings.profileBottomDeleteTitle,
-      primaryAction: BlocProvider.value(
-        value: deleteProfileCubit,
-        child: BlocBuilder<DeleteProfileCubit, DeleteProfileState>(
-          builder: (context, state) {
-            final isInProgress = state.maybeWhen(
-              inProgress: () => true,
-              orElse: () => false,
-            );
-            return MainButton(
-              state: isInProgress ? ButtonState.loading : ButtonState.enabled,
-              onPressed: () => context.read<DeleteProfileCubit>().deleteProfile(),
-              child: const Text(AppStrings.profileBottomDeleteConfirm),
-            );
-          },
+    try {
+      await showAppActionDialog(
+        context,
+        title: AppStrings.profileBottomDeleteTitle,
+        primaryAction: BlocProvider.value(
+          value: deleteProfileCubit,
+          child: BlocBuilder<DeleteProfileCubit, DeleteProfileState>(
+            builder: (context, state) {
+              final isInProgress = state.maybeWhen(
+                inProgress: () => true,
+                orElse: () => false,
+              );
+              return MainButton(
+                state: isInProgress ? ButtonState.loading : ButtonState.enabled,
+                onPressed: () => context.read<DeleteProfileCubit>().deleteProfile(),
+                child: const Text(AppStrings.profileBottomDeleteConfirm),
+              );
+            },
+          ),
         ),
-      ),
-      secondaryAction: BlocProvider.value(
-        value: deleteProfileCubit,
-        child: BlocBuilder<DeleteProfileCubit, DeleteProfileState>(
-          builder: (context, state) {
-            final isInProgress = state.maybeWhen(
-              inProgress: () => true,
-              orElse: () => false,
-            );
-            return SecondaryButton(
-              state: isInProgress ? ButtonState.disabled : ButtonState.enabled,
-              onPressed: _closeActiveDialog,
-              child: const Text(AppStrings.profileCancelButton),
-            );
-          },
+        secondaryAction: BlocProvider.value(
+          value: deleteProfileCubit,
+          child: BlocBuilder<DeleteProfileCubit, DeleteProfileState>(
+            builder: (context, state) {
+              final isInProgress = state.maybeWhen(
+                inProgress: () => true,
+                orElse: () => false,
+              );
+              return SecondaryButton(
+                state: isInProgress ? ButtonState.disabled : ButtonState.enabled,
+                onPressed: _closeActiveDialog,
+                child: const Text(AppStrings.profileCancelButton),
+              );
+            },
+          ),
         ),
-      ),
-    );
-    _isDeleteDialogOpen = false;
+      );
+    } finally {
+      _isDeleteDialogOpen = false;
+    }
   }
 
   void _closeActiveDialog() {
     final navigator = Navigator.of(context, rootNavigator: true);
     if (!navigator.canPop()) return;
+
+    Route<dynamic>? topRoute;
+    navigator.popUntil((route) {
+      topRoute = route;
+      return true;
+    });
+    if (topRoute is! PopupRoute<dynamic>) return;
+
     navigator.pop();
   }
 

--- a/test/features/auth/presentation/cubits/auth_session_cubit_test.dart
+++ b/test/features/auth/presentation/cubits/auth_session_cubit_test.dart
@@ -415,6 +415,37 @@ void main() {
     );
 
     blocTest<AuthSessionCubit, AuthSessionState>(
+      'signOut deletes access token and clears session',
+      setUp: () {
+        when(tokenStorage.deleteAccessToken()).thenAnswer((_) async {});
+      },
+      build: () => authSessionCubit,
+      act: (cubit) => cubit.signOut(),
+      expect: () => const [AuthSessionState.unauthenticated()],
+      verify: (_) {
+        verify(tokenStorage.deleteAccessToken()).called(1);
+        verify(progressStorage.clear()).called(1);
+        verify(guestSessionStorage.clear()).called(1);
+      },
+    );
+
+    blocTest<AuthSessionCubit, AuthSessionState>(
+      'signOut emits unauthenticated even when token deletion fails',
+      setUp: () {
+        when(tokenStorage.deleteAccessToken()).thenThrow(Exception('storage_error'));
+      },
+      build: () => authSessionCubit,
+      act: (cubit) => cubit.signOut(),
+      expect: () => const [AuthSessionState.unauthenticated()],
+      verify: (_) {
+        verify(tokenStorage.deleteAccessToken()).called(1);
+        verify(progressStorage.clear()).called(1);
+        verify(guestSessionStorage.clear()).called(1);
+        verify(logger.e(any, any, any)).called(1);
+      },
+    );
+
+    blocTest<AuthSessionCubit, AuthSessionState>(
       'restoreSession works only once when called twice',
       setUp: () {
         when(tokenStorage.getAccessToken()).thenAnswer((_) async => 'token');

--- a/test/features/profile/data/repositories/profile_repository_impl_test.dart
+++ b/test/features/profile/data/repositories/profile_repository_impl_test.dart
@@ -704,5 +704,60 @@ void main() {
         verifyNoMoreInteractions(apiClient);
       });
     });
+
+    group('deleteProfile', () {
+      test('returns success when api succeeds', () async {
+        // Arrange
+        when(apiClient.deleteProfile()).thenAnswer((_) async {});
+
+        // Act
+        final result = await repository.deleteProfile();
+
+        // Assert
+        expect(result.isSuccess, isTrue);
+
+        verify(apiClient.deleteProfile()).called(1);
+        verifyNoMoreInteractions(apiClient);
+      });
+
+      test('returns ProfileRequestFailure when api returns server error', () async {
+        // Arrange
+        final exception = createProfileDioBadResponseException(
+          path: '/api/profile',
+          statusCode: 500,
+          code: 'server_error',
+        );
+        when(apiClient.deleteProfile()).thenThrow(exception);
+
+        // Act
+        final result = await repository.deleteProfile();
+
+        // Assert
+        expect(result.isFailure, isTrue);
+        expect(result.failure, isA<ProfileRequestFailure>());
+        expect(result.failure!.parentException, exception);
+
+        verify(apiClient.deleteProfile()).called(1);
+        verifyNoMoreInteractions(apiClient);
+      });
+
+      test('returns UnknownProfileFailure when unexpected exception occurs', () async {
+        // Arrange
+        final exception = Exception('unexpected_error');
+        when(apiClient.deleteProfile()).thenThrow(exception);
+
+        // Act
+        final result = await repository.deleteProfile();
+
+        // Assert
+        expect(result.isFailure, isTrue);
+        expect(result.failure, isA<UnknownProfileFailure>());
+        expect(result.failure!.parentException, exception);
+
+        verify(apiClient.deleteProfile()).called(1);
+        verify(logger.e(any, exception, any)).called(1);
+        verifyNoMoreInteractions(apiClient);
+      });
+    });
   });
 }

--- a/test/features/profile/presentation/cubits/delete_profile_cubit_test.dart
+++ b/test/features/profile/presentation/cubits/delete_profile_cubit_test.dart
@@ -1,0 +1,65 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:moveup_flutter/core/failures/feature/profile/profile_failure.dart';
+import 'package:moveup_flutter/core/result/result.dart';
+import 'package:moveup_flutter/features/profile/domain/repositories/profile_repository.dart';
+import 'package:moveup_flutter/features/profile/presentation/cubits/delete_profile_cubit.dart';
+
+import 'delete_profile_cubit_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<ProfileRepository>()])
+void main() {
+  late MockProfileRepository repository;
+  late DeleteProfileCubit cubit;
+
+  const failure = ProfileRequestFailure('test');
+
+  setUp(() {
+    repository = MockProfileRepository();
+    cubit = DeleteProfileCubit(repository);
+    provideDummy<Result<void, ProfileFailure>>(const Success(null));
+  });
+
+  group('DeleteProfileCubit', () {
+    blocTest<DeleteProfileCubit, DeleteProfileState>(
+      'emits inProgress and succeed when profile deletion succeeds',
+      setUp: () => when(repository.deleteProfile()).thenAnswer((_) async => const Success(null)),
+      build: () => cubit,
+      act: (cubit) => cubit.deleteProfile(),
+      expect: () => const [
+        DeleteProfileState.inProgress(),
+        DeleteProfileState.succeed(),
+      ],
+      verify: (_) => verify(repository.deleteProfile()).called(1),
+    );
+
+    blocTest<DeleteProfileCubit, DeleteProfileState>(
+      'emits failed(failure) when profile deletion fails',
+      setUp: () => when(repository.deleteProfile()).thenAnswer((_) async => const Failure(failure)),
+      build: () => cubit,
+      act: (cubit) => cubit.deleteProfile(),
+      expect: () => const [
+        DeleteProfileState.inProgress(),
+        DeleteProfileState.failed(failure),
+      ],
+      verify: (_) => verify(repository.deleteProfile()).called(1),
+    );
+
+    blocTest<DeleteProfileCubit, DeleteProfileState>(
+      'emits inProgress only once when deleteProfile is called twice',
+      setUp: () => when(repository.deleteProfile()).thenAnswer((_) async => const Success(null)),
+      build: () => cubit,
+      act: (cubit) {
+        cubit.deleteProfile();
+        cubit.deleteProfile();
+      },
+      expect: () => const [
+        DeleteProfileState.inProgress(),
+        DeleteProfileState.succeed(),
+      ],
+      verify: (_) => verify(repository.deleteProfile()).called(1),
+    );
+  });
+}


### PR DESCRIPTION
## 🚀 Summary

Implemented the bottom section of authenticated `/profile`, adding logout and delete-profile confirmation flows plus direct access to bundled legal documents. The feature reuses the existing auth logout contract, adds the missing `DELETE /api/profile` command, and introduces a dedicated authenticated `signOut()` cleanup path in `AuthSessionCubit` so both logout and profile deletion consistently clear the local session and redirect back to sign-in.

## ✨ Changes

- ✅ Added authenticated `AuthSessionCubit.signOut()` to clear the stored access token and then run the existing local session cleanup flow
- ✅ Switched the remaining debug logout cleanup path to the shared authenticated sign-out method, then simplified the debug screen back to a centered placeholder
- ✅ Added `DELETE /api/profile` support in `ProfileApiClient`, `ProfileRepository`, and `ProfileRepositoryImpl`
- ✅ Added `DeleteProfileCubit` with duplicate-submit protection and profile failure handling
- ✅ Added repository test coverage for `deleteProfile()` success, request failure, and unexpected failure
- ✅ Added cubit test coverage for `DeleteProfileCubit` success, failure, and repeated-submit guard
- ✅ Added `ProfileBottomSectionWidget` to `/profile` with: logout and delete profile confirm flow and direct legal document links
- ✅ Wired profile bottom actions into `ProfilePageBuilder` with `LogoutCubit` and `DeleteProfileCubit`
- ✅ Moved legal documents routing out of the auth-prefixed path so documents can be opened from authenticated `/profile` without redirecting back to `/workouts`
- ✅ Updated profile bottom legal links to use a profile-local text-link presentation matching the provided mockup

## 🧪 Verification

- [x] `flutter analyze`
- [x] `flutter test test/features/auth/presentation/cubits/auth_session_cubit_test.dart`
- [x] `flutter test test/features/profile`
