### PR TITLE
feat(subscriptions): add authenticated subscriptions catalog and profile entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Profile current phase section for the authenticated `/profile` tab, reusing the bootstrap profile phase snapshot plus aggregate statistics frequency summary to render the read-only phase block without a standalone phase slice.
 - Introduce personal parameters section for the authenticated `/profile` tab, including canonical `user-parameters` read/update flow, editable profile form card, weekly-goal save support, and selective workouts overview refresh when goal, equipment, or level changes regenerate the personal plan.
 - Add profile bottom section for the authenticated `/profile` tab, including logout and delete-profile confirmation actions plus direct links to the bundled legal documents.
+- Authenticated subscriptions catalog screen, including dedicated subscriptions route, catalog Cubit, card UI with normalized remote images, and a profile CTA for opening available subscription plans.
 
 ### Changed
 
@@ -39,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Shared `OptionButton` now supports canonical `large` and `small` size presets, and the profile statistics plus history-tab controls use the compact 42px variant from the mockups.
 - Profile dialogs now support per-dialog content padding and optional barrier dismissal, allowing the statistics history modal to match the provided sheet behavior without affecting non-dismissible dialogs.
 - The debug route is now a static centered placeholder again and no longer owns a separate logout flow.
+- `AppCard` now supports an optional fixed height, allowing specialized screens like the subscriptions catalog to match exact card mockups without introducing a forked card component.
 
 ### Breaking
 

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -209,6 +209,9 @@ abstract final class AppStrings {
   static const workoutsUnknown = 'Не удалось выполнить действие. Попробуйте снова';
 
   // Subscriptions catalog.
+  static const subscriptionsCatalogTitle = 'Подписки';
+  static const subscriptionsCatalogEmpty = 'Подписки не найдены';
+  static const subscriptionsCatalogLoadFailed = 'Не удалось загрузить подписки';
   static const subscriptionsUnknown = 'Не удалось выполнить действие. Попробуйте снова';
 
   // Workout details.
@@ -285,6 +288,10 @@ abstract final class AppStrings {
   static const profileBottomLogoutTitle = 'Вы уверены, что хотите выйти?';
   static const profileBottomDeleteTitle = 'Вы уверены, что хотите удалить профиль?';
   static const profileBottomDeleteConfirm = 'Удалить';
+  static const profileSubscriptionsButton = 'Выбрать подписку';
+  static const subscriptionsCatalogBenefitTests =
+      'Расширенный набор тестов для качественной адаптации';
+  static const subscriptionsCatalogBenefitExercises = 'Расширенный набор упражнений';
   static const profileStatsTitle = 'Статистика тренировок пользователя';
   static const profileStatsHistoryButton = 'История';
   static const profileStatsVolumeMode = 'Объём';

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -208,6 +208,9 @@ abstract final class AppStrings {
       'У вас уже есть начатая тренировка. Сначала завершите её, чтобы начать новую';
   static const workoutsUnknown = 'Не удалось выполнить действие. Попробуйте снова';
 
+  // Subscriptions catalog.
+  static const subscriptionsUnknown = 'Не удалось выполнить действие. Попробуйте снова';
+
   // Workout details.
   static const workoutDetailsTitle = 'Тренировка';
   static const workoutDetailsStartWarmupButton = 'Начать разминку';

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -212,6 +212,10 @@ abstract final class AppStrings {
   static const subscriptionsCatalogTitle = 'Подписки';
   static const subscriptionsCatalogEmpty = 'Подписки не найдены';
   static const subscriptionsCatalogLoadFailed = 'Не удалось загрузить подписки';
+  static const subscriptionsCatalogBenefitTests =
+      'Расширенный набор тестов для качественной адаптации';
+  static const subscriptionsCatalogBenefitExercises = 'Расширенный набор упражнений';
+  static const subscriptionsCatalogRubles = 'рублей';
   static const subscriptionsUnknown = 'Не удалось выполнить действие. Попробуйте снова';
 
   // Workout details.
@@ -289,9 +293,6 @@ abstract final class AppStrings {
   static const profileBottomDeleteTitle = 'Вы уверены, что хотите удалить профиль?';
   static const profileBottomDeleteConfirm = 'Удалить';
   static const profileSubscriptionsButton = 'Выбрать подписку';
-  static const subscriptionsCatalogBenefitTests =
-      'Расширенный набор тестов для качественной адаптации';
-  static const subscriptionsCatalogBenefitExercises = 'Расширенный набор упражнений';
   static const profileStatsTitle = 'Статистика тренировок пользователя';
   static const profileStatsHistoryButton = 'История';
   static const profileStatsVolumeMode = 'Объём';

--- a/lib/core/di/di.dart
+++ b/lib/core/di/di.dart
@@ -26,6 +26,9 @@ import '../../features/profile/data/repositories/profile_statistics_repository_i
 import '../../features/profile/domain/repositories/profile_parameters_repository.dart';
 import '../../features/profile/domain/repositories/profile_repository.dart';
 import '../../features/profile/domain/repositories/profile_statistics_repository.dart';
+import '../../features/subscriptions/data/remote/subscriptions_api_client.dart';
+import '../../features/subscriptions/data/repositories/subscriptions_repository_impl.dart';
+import '../../features/subscriptions/domain/repositories/subscriptions_repository.dart';
 import '../../features/tests/attempt/data/repositories/authenticated_test_attempt_repository_impl.dart';
 import '../../features/tests/attempt/data/repositories/guest_test_attempt_repository_impl.dart';
 import '../../features/tests/attempt/domain/repositories/test_attempt_repository.dart';
@@ -145,6 +148,13 @@ Future<void> setupDI() async {
     () => ProfileParametersRepositoryImpl(
       di<AppLogger>(),
       di<ProfileParametersApiClient>(),
+    ),
+  );
+  di.registerLazySingleton<SubscriptionsApiClient>(() => SubscriptionsApiClient(di<Dio>()));
+  di.registerLazySingleton<SubscriptionsRepository>(
+    () => SubscriptionsRepositoryImpl(
+      di<AppLogger>(),
+      di<SubscriptionsApiClient>(),
     ),
   );
 

--- a/lib/core/failures/feature/subscriptions/subscriptions_failure.dart
+++ b/lib/core/failures/feature/subscriptions/subscriptions_failure.dart
@@ -1,0 +1,31 @@
+import '../../../constants/app_strings.dart';
+import '../../app_failure.dart';
+
+/// Subscriptions application error.
+sealed class SubscriptionsFailure extends AppFailure {
+  /// Creates an instance of [SubscriptionsFailure].
+  const SubscriptionsFailure(
+    super.message, {
+    super.parentException,
+    super.stackTrace,
+  });
+}
+
+/// Subscriptions request failed because of infrastructure or network conditions.
+final class SubscriptionsRequestFailure extends SubscriptionsFailure {
+  /// Creates an instance of [SubscriptionsRequestFailure].
+  const SubscriptionsRequestFailure(
+    super.message, {
+    super.parentException,
+    super.stackTrace,
+  });
+}
+
+/// Unknown subscriptions failure.
+final class UnknownSubscriptionsFailure extends SubscriptionsFailure {
+  /// Creates an instance of [UnknownSubscriptionsFailure].
+  const UnknownSubscriptionsFailure({
+    super.parentException,
+    super.stackTrace,
+  }) : super(AppStrings.subscriptionsUnknown);
+}

--- a/lib/core/network/api_paths.dart
+++ b/lib/core/network/api_paths.dart
@@ -104,6 +104,9 @@ abstract class ApiPaths {
   /// The endpoint for the current user workouts overview.
   static const String workouts = '${apiPrefix}workouts';
 
+  /// The endpoint for the subscriptions catalog.
+  static const String subscriptions = '${apiPrefix}subscriptions';
+
   /// The endpoint for starting a workout.
   static const String workoutsStart = '$workouts/start';
 

--- a/lib/core/network/mappers/image_url_mapper.dart
+++ b/lib/core/network/mappers/image_url_mapper.dart
@@ -1,0 +1,16 @@
+import '../api_paths.dart';
+
+/// Normalizes relative backend image paths into absolute URLs.
+String normalizeBackendImageUrl(String rawImage) {
+  final image = rawImage.trim();
+  if (image.isEmpty) return '';
+  if (image.startsWith('http://') || image.startsWith('https://')) {
+    return image;
+  }
+
+  final normalizedPath = image.replaceFirst(RegExp(r'^/+'), '');
+  final storagePath = normalizedPath.startsWith('storage/')
+      ? normalizedPath
+      : 'storage/$normalizedPath';
+  return Uri.parse(ApiPaths.baseUrl).resolve(storagePath).toString();
+}

--- a/lib/core/router/router.dart
+++ b/lib/core/router/router.dart
@@ -23,6 +23,7 @@ import '../../features/offline/presentation/pages/offline_page.dart';
 import '../../features/profile/presentation/pages/profile_page_builder.dart';
 import '../../features/root/presentation/pages/root_screen.dart';
 import '../../features/splash/presentation/pages/splash_page.dart';
+import '../../features/subscriptions/presentation/pages/subscriptions_catalog_page_builder.dart';
 import '../../features/tests/attempt/presentation/pages/tests_attempt_page_builder.dart';
 import '../../features/tests/catalog/presentation/pages/tests_catalog_page_builder.dart';
 import '../../features/workouts/details/presentation/pages/workout_details_page_builder.dart';
@@ -270,6 +271,10 @@ final router = GoRouter(
     GoRoute(
       path: AppRoutePaths.offlinePath,
       builder: (context, state) => const OfflinePage(),
+    ),
+    GoRoute(
+      path: AppRoutePaths.subscriptionsCatalogPath,
+      builder: (_, _) => const SubscriptionsCatalogPageBuilder(),
     ),
     GoRoute(
       path: AppRoutePaths.signInPath,

--- a/lib/core/router/router_paths.dart
+++ b/lib/core/router/router_paths.dart
@@ -67,6 +67,9 @@ abstract class AppRoutePaths {
   /// Route path for workouts overview.
   static const workoutsPath = '/workouts';
 
+  /// Route path for subscriptions catalog.
+  static const subscriptionsCatalogPath = '/subscriptions';
+
   /// Base route path for a concrete workout details screen.
   static const workoutDetailsBasePath = '$workoutsPath/details';
 

--- a/lib/features/profile/presentation/pages/profile_page.dart
+++ b/lib/features/profile/presentation/pages/profile_page.dart
@@ -119,7 +119,12 @@ class ProfilePage extends StatelessWidget {
                     onPressed: () => _openHistoryDialog(context),
                     child: const Text(AppStrings.profileStatsHistoryButton),
                   ),
-                  const SizedBox(height: 36),
+                  const SizedBox(height: 24),
+                  MainButton(
+                    onPressed: () => context.push(AppRoutePaths.subscriptionsCatalogPath),
+                    child: const Text(AppStrings.profileSubscriptionsButton),
+                  ),
+                  const SizedBox(height: 24),
                   const CurrentPhaseSectionWidget(),
                   const SizedBox(height: 36),
                   const ProfileParametersSectionWidget(),

--- a/lib/features/subscriptions/data/dto/subscription_catalog_item_dto.dart
+++ b/lib/features/subscriptions/data/dto/subscription_catalog_item_dto.dart
@@ -22,7 +22,7 @@ class SubscriptionCatalogItemDto {
 
   /// Subscription duration in days.
   @JsonKey(name: 'duration_days')
-  final String durationDays;
+  final int durationDays;
 
   /// Whether the subscription is active in the catalog.
   @JsonKey(name: 'is_active')

--- a/lib/features/subscriptions/data/dto/subscription_catalog_item_dto.dart
+++ b/lib/features/subscriptions/data/dto/subscription_catalog_item_dto.dart
@@ -1,0 +1,45 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'subscription_catalog_item_dto.g.dart';
+
+/// DTO for a subscriptions catalog item.
+@JsonSerializable(createToJson: false)
+class SubscriptionCatalogItemDto {
+  /// Subscription identifier.
+  final int id;
+
+  /// Subscription backend name.
+  final String name;
+
+  /// Subscription description.
+  final String description;
+
+  /// Subscription image path or URL.
+  final String image;
+
+  /// Subscription price.
+  final String price;
+
+  /// Subscription duration in days.
+  @JsonKey(name: 'duration_days')
+  final String durationDays;
+
+  /// Whether the subscription is active in the catalog.
+  @JsonKey(name: 'is_active')
+  final bool isActive;
+
+  /// Creates an instance of [SubscriptionCatalogItemDto].
+  SubscriptionCatalogItemDto({
+    required this.id,
+    required this.name,
+    required this.description,
+    required this.image,
+    required this.price,
+    required this.durationDays,
+    required this.isActive,
+  });
+
+  /// Creates a [SubscriptionCatalogItemDto] from JSON.
+  factory SubscriptionCatalogItemDto.fromJson(Map<String, dynamic> json) =>
+      _$SubscriptionCatalogItemDtoFromJson(json);
+}

--- a/lib/features/subscriptions/data/dto/subscriptions_response_dto.dart
+++ b/lib/features/subscriptions/data/dto/subscriptions_response_dto.dart
@@ -1,0 +1,19 @@
+import 'package:json_annotation/json_annotation.dart';
+
+import 'subscription_catalog_item_dto.dart';
+
+part 'subscriptions_response_dto.g.dart';
+
+/// DTO for subscriptions response envelope.
+@JsonSerializable(createToJson: false)
+class SubscriptionsResponseDto {
+  /// Subscriptions payload.
+  final List<SubscriptionCatalogItemDto> data;
+
+  /// Creates an instance of [SubscriptionsResponseDto].
+  SubscriptionsResponseDto({required this.data});
+
+  /// Creates a [SubscriptionsResponseDto] from JSON.
+  factory SubscriptionsResponseDto.fromJson(Map<String, dynamic> json) =>
+      _$SubscriptionsResponseDtoFromJson(json);
+}

--- a/lib/features/subscriptions/data/mappers/subscription_catalog_mapper.dart
+++ b/lib/features/subscriptions/data/mappers/subscription_catalog_mapper.dart
@@ -1,0 +1,15 @@
+import '../../domain/entities/subscription_catalog_item.dart';
+import '../dto/subscription_catalog_item_dto.dart';
+import 'subscription_image_url_mapper.dart';
+
+/// Extension that maps [SubscriptionCatalogItemDto] to [SubscriptionCatalogItem].
+extension SubscriptionCatalogItemMapper on SubscriptionCatalogItemDto {
+  /// Converts DTO to a domain entity.
+  SubscriptionCatalogItem toEntity() => SubscriptionCatalogItem(
+    id: id,
+    description: description,
+    price: price,
+    durationDays: int.tryParse(durationDays.trim()) ?? 0,
+    imageUrl: normalizeSubscriptionImageUrl(image),
+  );
+}

--- a/lib/features/subscriptions/data/mappers/subscription_catalog_mapper.dart
+++ b/lib/features/subscriptions/data/mappers/subscription_catalog_mapper.dart
@@ -7,9 +7,10 @@ extension SubscriptionCatalogItemMapper on SubscriptionCatalogItemDto {
   /// Converts DTO to a domain entity.
   SubscriptionCatalogItem toEntity() => SubscriptionCatalogItem(
     id: id,
+    name: name,
     description: description,
     price: price,
-    durationDays: int.tryParse(durationDays.trim()) ?? 0,
+    durationDays: durationDays,
     imageUrl: normalizeSubscriptionImageUrl(image),
   );
 }

--- a/lib/features/subscriptions/data/mappers/subscription_catalog_mapper.dart
+++ b/lib/features/subscriptions/data/mappers/subscription_catalog_mapper.dart
@@ -10,7 +10,6 @@ extension SubscriptionCatalogItemMapper on SubscriptionCatalogItemDto {
     name: name,
     description: description,
     price: price,
-    durationDays: durationDays,
     imageUrl: normalizeSubscriptionImageUrl(image),
   );
 }

--- a/lib/features/subscriptions/data/mappers/subscription_image_url_mapper.dart
+++ b/lib/features/subscriptions/data/mappers/subscription_image_url_mapper.dart
@@ -1,0 +1,16 @@
+import '../../../../core/network/api_paths.dart';
+
+/// Normalizes relative backend subscription image paths into absolute URLs.
+String normalizeSubscriptionImageUrl(String rawImage) {
+  final image = rawImage.trim();
+  if (image.isEmpty) return '';
+  if (image.startsWith('http://') || image.startsWith('https://')) {
+    return image;
+  }
+
+  final normalizedPath = image.replaceFirst(RegExp(r'^/+'), '');
+  final storagePath = normalizedPath.startsWith('storage/')
+      ? normalizedPath
+      : 'storage/$normalizedPath';
+  return Uri.parse(ApiPaths.baseUrl).resolve(storagePath).toString();
+}

--- a/lib/features/subscriptions/data/mappers/subscription_image_url_mapper.dart
+++ b/lib/features/subscriptions/data/mappers/subscription_image_url_mapper.dart
@@ -1,16 +1,4 @@
-import '../../../../core/network/api_paths.dart';
+import '../../../../core/network/mappers/image_url_mapper.dart';
 
 /// Normalizes relative backend subscription image paths into absolute URLs.
-String normalizeSubscriptionImageUrl(String rawImage) {
-  final image = rawImage.trim();
-  if (image.isEmpty) return '';
-  if (image.startsWith('http://') || image.startsWith('https://')) {
-    return image;
-  }
-
-  final normalizedPath = image.replaceFirst(RegExp(r'^/+'), '');
-  final storagePath = normalizedPath.startsWith('storage/')
-      ? normalizedPath
-      : 'storage/$normalizedPath';
-  return Uri.parse(ApiPaths.baseUrl).resolve(storagePath).toString();
-}
+String normalizeSubscriptionImageUrl(String rawImage) => normalizeBackendImageUrl(rawImage);

--- a/lib/features/subscriptions/data/mappers/subscriptions_failure_mapper.dart
+++ b/lib/features/subscriptions/data/mappers/subscriptions_failure_mapper.dart
@@ -1,0 +1,26 @@
+import '../../../../core/failures/feature/subscriptions/subscriptions_failure.dart';
+import '../../../../core/failures/network/network_failure.dart';
+
+/// Extension to map [NetworkFailure] into [SubscriptionsFailure].
+extension SubscriptionsFailureMapper on NetworkFailure {
+  /// Maps a [NetworkFailure] into a subscriptions-specific failure.
+  SubscriptionsFailure toSubscriptionsFailure() {
+    return switch (this) {
+      NoNetworkFailure() ||
+      ConnectionTimeoutFailure() ||
+      BadRequestFailure() ||
+      UnauthorizedFailure() ||
+      ForbiddenFailure() ||
+      NotFoundFailure() ||
+      ConflictFailure() ||
+      ValidationFailure() ||
+      RateLimitedFailure() ||
+      ServerErrorFailure() ||
+      UnknownNetworkFailure() => SubscriptionsRequestFailure(
+        message,
+        parentException: parentException,
+        stackTrace: stackTrace,
+      ),
+    };
+  }
+}

--- a/lib/features/subscriptions/data/remote/subscriptions_api_client.dart
+++ b/lib/features/subscriptions/data/remote/subscriptions_api_client.dart
@@ -1,0 +1,18 @@
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../../../../core/network/api_paths.dart';
+import '../dto/subscriptions_response_dto.dart';
+
+part 'subscriptions_api_client.g.dart';
+
+/// Retrofit API client for subscriptions catalog requests.
+@RestApi()
+abstract class SubscriptionsApiClient {
+  /// Creates an instance of [SubscriptionsApiClient].
+  factory SubscriptionsApiClient(Dio dio, {String? baseUrl}) = _SubscriptionsApiClient;
+
+  /// Returns all subscriptions available in the catalog.
+  @GET(ApiPaths.subscriptions)
+  Future<SubscriptionsResponseDto> getSubscriptions();
+}

--- a/lib/features/subscriptions/data/repositories/subscriptions_repository_impl.dart
+++ b/lib/features/subscriptions/data/repositories/subscriptions_repository_impl.dart
@@ -1,0 +1,40 @@
+import 'package:dio/dio.dart';
+
+import '../../../../core/failures/feature/subscriptions/subscriptions_failure.dart';
+import '../../../../core/network/mappers/dio_exception_mapper.dart';
+import '../../../../core/result/result.dart';
+import '../../../../core/utils/logger/app_logger.dart';
+import '../../domain/entities/subscription_catalog_item.dart';
+import '../../domain/repositories/subscriptions_repository.dart';
+import '../mappers/subscription_catalog_mapper.dart';
+import '../mappers/subscriptions_failure_mapper.dart';
+import '../remote/subscriptions_api_client.dart';
+
+/// Implementation of [SubscriptionsRepository].
+final class SubscriptionsRepositoryImpl implements SubscriptionsRepository {
+  /// Logger for tracking subscriptions catalog operations and errors.
+  final AppLogger _logger;
+
+  /// API client for subscriptions catalog requests.
+  final SubscriptionsApiClient _apiClient;
+
+  /// Creates an instance of [SubscriptionsRepositoryImpl].
+  SubscriptionsRepositoryImpl(this._logger, this._apiClient);
+
+  @override
+  Future<Result<List<SubscriptionCatalogItem>, SubscriptionsFailure>> getSubscriptions() async {
+    try {
+      final response = await _apiClient.getSubscriptions();
+      final items = response.data.map((item) => item.toEntity()).toList(growable: false);
+      return Result.success(items);
+    } on DioException catch (e) {
+      final networkFailure = e.toNetworkFailure();
+      return Result.failure(networkFailure.toSubscriptionsFailure());
+    } catch (e, s) {
+      _logger.e('GetSubscriptions failed with unexpected error', e, s);
+      return Result.failure(
+        UnknownSubscriptionsFailure(parentException: e, stackTrace: s),
+      );
+    }
+  }
+}

--- a/lib/features/subscriptions/data/repositories/subscriptions_repository_impl.dart
+++ b/lib/features/subscriptions/data/repositories/subscriptions_repository_impl.dart
@@ -25,7 +25,10 @@ final class SubscriptionsRepositoryImpl implements SubscriptionsRepository {
   Future<Result<List<SubscriptionCatalogItem>, SubscriptionsFailure>> getSubscriptions() async {
     try {
       final response = await _apiClient.getSubscriptions();
-      final items = response.data.map((item) => item.toEntity()).toList(growable: false);
+      final items = response.data
+          .where((item) => item.isActive)
+          .map((item) => item.toEntity())
+          .toList(growable: false);
       return Result.success(items);
     } on DioException catch (e) {
       final networkFailure = e.toNetworkFailure();

--- a/lib/features/subscriptions/domain/entities/subscription_catalog_item.dart
+++ b/lib/features/subscriptions/domain/entities/subscription_catalog_item.dart
@@ -5,6 +5,9 @@ final class SubscriptionCatalogItem extends Equatable {
   /// Subscription identifier.
   final int id;
 
+  /// Subscription marketing name from catalog.
+  final String name;
+
   /// Subscription description.
   final String description;
 
@@ -20,6 +23,7 @@ final class SubscriptionCatalogItem extends Equatable {
   /// Creates an instance of [SubscriptionCatalogItem].
   const SubscriptionCatalogItem({
     required this.id,
+    required this.name,
     required this.description,
     required this.price,
     required this.durationDays,
@@ -29,6 +33,7 @@ final class SubscriptionCatalogItem extends Equatable {
   @override
   List<Object?> get props => [
     id,
+    name,
     description,
     price,
     durationDays,

--- a/lib/features/subscriptions/domain/entities/subscription_catalog_item.dart
+++ b/lib/features/subscriptions/domain/entities/subscription_catalog_item.dart
@@ -1,0 +1,37 @@
+import 'package:equatable/equatable.dart';
+
+/// Catalog item returned by the subscriptions endpoint.
+final class SubscriptionCatalogItem extends Equatable {
+  /// Subscription identifier.
+  final int id;
+
+  /// Subscription description.
+  final String description;
+
+  /// Subscription price.
+  final String price;
+
+  /// Subscription duration in days.
+  final int durationDays;
+
+  /// Normalized subscription image URL.
+  final String imageUrl;
+
+  /// Creates an instance of [SubscriptionCatalogItem].
+  const SubscriptionCatalogItem({
+    required this.id,
+    required this.description,
+    required this.price,
+    required this.durationDays,
+    required this.imageUrl,
+  });
+
+  @override
+  List<Object?> get props => [
+    id,
+    description,
+    price,
+    durationDays,
+    imageUrl,
+  ];
+}

--- a/lib/features/subscriptions/domain/entities/subscription_catalog_item.dart
+++ b/lib/features/subscriptions/domain/entities/subscription_catalog_item.dart
@@ -14,9 +14,6 @@ final class SubscriptionCatalogItem extends Equatable {
   /// Subscription price.
   final String price;
 
-  /// Subscription duration in days.
-  final int durationDays;
-
   /// Normalized subscription image URL.
   final String imageUrl;
 
@@ -26,7 +23,6 @@ final class SubscriptionCatalogItem extends Equatable {
     required this.name,
     required this.description,
     required this.price,
-    required this.durationDays,
     required this.imageUrl,
   });
 
@@ -36,7 +32,6 @@ final class SubscriptionCatalogItem extends Equatable {
     name,
     description,
     price,
-    durationDays,
     imageUrl,
   ];
 }

--- a/lib/features/subscriptions/domain/repositories/subscriptions_repository.dart
+++ b/lib/features/subscriptions/domain/repositories/subscriptions_repository.dart
@@ -1,0 +1,9 @@
+import '../../../../core/failures/feature/subscriptions/subscriptions_failure.dart';
+import '../../../../core/result/result.dart';
+import '../entities/subscription_catalog_item.dart';
+
+/// Repository interface for subscriptions catalog operations.
+abstract interface class SubscriptionsRepository {
+  /// Returns all subscriptions available for the catalog screen.
+  Future<Result<List<SubscriptionCatalogItem>, SubscriptionsFailure>> getSubscriptions();
+}

--- a/lib/features/subscriptions/presentation/cubits/subscriptions_cubit.dart
+++ b/lib/features/subscriptions/presentation/cubits/subscriptions_cubit.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../../../core/failures/feature/subscriptions/subscriptions_failure.dart';
+import '../../../../core/result/result.dart';
+import '../../domain/entities/subscription_catalog_item.dart';
+import '../../domain/repositories/subscriptions_repository.dart';
+
+part 'subscriptions_cubit.freezed.dart';
+part 'subscriptions_state.dart';
+
+/// Cubit that manages subscriptions catalog loading flow and emits [SubscriptionsState].
+final class SubscriptionsCubit extends Cubit<SubscriptionsState> {
+  /// Repository used for subscriptions catalog requests.
+  final SubscriptionsRepository _repository;
+
+  /// Creates an instance of [SubscriptionsCubit].
+  SubscriptionsCubit(this._repository) : super(const SubscriptionsState.initial());
+
+  /// Loads all subscriptions available for the catalog screen.
+  Future<void> loadSubscriptions() async {
+    final isInProgress = state.maybeWhen(
+      inProgress: () => true,
+      orElse: () => false,
+    );
+    if (isInProgress) return;
+
+    emit(const SubscriptionsState.inProgress());
+
+    final result = await _repository.getSubscriptions();
+    if (isClosed) return;
+
+    switch (result) {
+      case Success(:final data):
+        emit(SubscriptionsState.loaded(data));
+      case Failure(:final error):
+        emit(SubscriptionsState.failed(error));
+    }
+  }
+}

--- a/lib/features/subscriptions/presentation/cubits/subscriptions_state.dart
+++ b/lib/features/subscriptions/presentation/cubits/subscriptions_state.dart
@@ -1,0 +1,17 @@
+part of 'subscriptions_cubit.dart';
+
+/// States for [SubscriptionsCubit].
+@freezed
+class SubscriptionsState with _$SubscriptionsState {
+  /// Initial idle state before subscriptions loading.
+  const factory SubscriptionsState.initial() = _Initial;
+
+  /// State emitted while subscriptions request is in progress.
+  const factory SubscriptionsState.inProgress() = _InProgress;
+
+  /// State emitted when subscriptions load successfully.
+  const factory SubscriptionsState.loaded(List<SubscriptionCatalogItem> items) = _Loaded;
+
+  /// State emitted when subscriptions loading fails.
+  const factory SubscriptionsState.failed(SubscriptionsFailure failure) = _Failed;
+}

--- a/lib/features/subscriptions/presentation/pages/subscriptions_catalog_page.dart
+++ b/lib/features/subscriptions/presentation/pages/subscriptions_catalog_page.dart
@@ -1,0 +1,152 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../core/constants/app_strings.dart';
+import '../../../../core/router/router_paths.dart';
+import '../../../../uikit/buttons/app_back_button.dart';
+import '../../../../uikit/buttons/main_button.dart';
+import '../../../../uikit/images/app_decorative_figure.dart';
+import '../../../../uikit/themes/colors/app_color_theme.dart';
+import '../../../../uikit/themes/text/app_text_theme.dart';
+import '../../domain/entities/subscription_catalog_item.dart';
+import '../cubits/subscriptions_cubit.dart';
+import '../widgets/subscription_card.dart';
+
+/// Fullscreen subscriptions catalog page.
+class SubscriptionsCatalogPage extends StatelessWidget {
+  /// Creates an instance of [SubscriptionsCatalogPage].
+  const SubscriptionsCatalogPage({super.key});
+
+  void _handleBack(BuildContext context) {
+    if (Navigator.canPop(context)) {
+      context.pop();
+      return;
+    }
+    context.go(AppRoutePaths.profilePath);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = AppTextTheme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        leading: AppBackButton(onPressed: () => _handleBack(context)),
+        title: Text(
+          AppStrings.subscriptionsCatalogTitle,
+          style: textTheme.appBarTitle,
+        ),
+      ),
+      body: BlocBuilder<SubscriptionsCubit, SubscriptionsState>(
+        builder: (context, state) {
+          return Stack(
+            fit: StackFit.expand,
+            children: [
+              Positioned(
+                left: -140,
+                top: 113,
+                child: IgnorePointer(
+                  child: ExcludeSemantics(
+                    child: Transform.scale(
+                      scaleY: -1,
+                      child: Transform.rotate(
+                        angle: -163 * (math.pi / 180),
+                        child: const AppDecorativeFigure(tone: FigureTone.primary),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              Positioned(
+                right: -80,
+                bottom: 20,
+                child: IgnorePointer(
+                  child: ExcludeSemantics(
+                    child: Transform.scale(
+                      scaleY: -1,
+                      child: Transform.rotate(
+                        angle: -180 * (math.pi / 180),
+                        child: const AppDecorativeFigure(tone: FigureTone.secondary),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              _buildStateSection(context, state),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildStateSection(BuildContext context, SubscriptionsState state) {
+    return state.when(
+      initial: () => const SizedBox.shrink(),
+      inProgress: _buildLoadingState,
+      loaded: _buildLoadedState,
+      failed: (_) => _buildRetryState(context),
+    );
+  }
+
+  Widget _buildLoadingState() {
+    return const Center(
+      child: SizedBox.square(
+        dimension: 24,
+        child: CircularProgressIndicator.adaptive(strokeWidth: 2),
+      ),
+    );
+  }
+
+  Widget _buildLoadedState(List<SubscriptionCatalogItem> items) {
+    if (items.isEmpty) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.symmetric(horizontal: 24),
+          child: Text(
+            AppStrings.subscriptionsCatalogEmpty,
+            textAlign: TextAlign.center,
+          ),
+        ),
+      );
+    }
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.fromLTRB(24, 28, 24, 48),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: List.generate(items.length, (index) {
+          final item = items[index];
+          return Padding(
+            padding: EdgeInsets.only(bottom: index == items.length - 1 ? 0 : 12),
+            child: SubscriptionCard(item: item),
+          );
+        }),
+      ),
+    );
+  }
+
+  Widget _buildRetryState(BuildContext context) {
+    final textTheme = AppTextTheme.of(context);
+    final colorTheme = AppColorTheme.of(context);
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            AppStrings.subscriptionsCatalogLoadFailed,
+            textAlign: TextAlign.center,
+            style: textTheme.bodyMedium.copyWith(color: colorTheme.onSurface),
+          ),
+          const SizedBox(height: 24),
+          MainButton(
+            onPressed: context.read<SubscriptionsCubit>().loadSubscriptions,
+            child: const Text(AppStrings.retryButton),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/subscriptions/presentation/pages/subscriptions_catalog_page_builder.dart
+++ b/lib/features/subscriptions/presentation/pages/subscriptions_catalog_page_builder.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../core/di/di.dart';
+import '../../domain/repositories/subscriptions_repository.dart';
+import '../cubits/subscriptions_cubit.dart';
+import 'subscriptions_catalog_page.dart';
+
+/// Builder for the subscriptions catalog page.
+class SubscriptionsCatalogPageBuilder extends StatelessWidget {
+  /// Creates an instance of [SubscriptionsCatalogPageBuilder].
+  const SubscriptionsCatalogPageBuilder({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => SubscriptionsCubit(
+        di<SubscriptionsRepository>(),
+      )..loadSubscriptions(),
+      child: const SubscriptionsCatalogPage(),
+    );
+  }
+}

--- a/lib/features/subscriptions/presentation/widgets/subscription_card.dart
+++ b/lib/features/subscriptions/presentation/widgets/subscription_card.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/constants/app_strings.dart';
+import '../../../../uikit/cards/app_card.dart';
+import '../../../../uikit/images/network_image_widget.dart';
+import '../../../../uikit/themes/colors/app_color_theme.dart';
+import '../../../../uikit/themes/text/app_text_theme.dart';
+import '../../domain/entities/subscription_catalog_item.dart';
+
+/// Visual card for a single subscriptions catalog item.
+class SubscriptionCard extends StatelessWidget {
+  /// Catalog item displayed by this card.
+  final SubscriptionCatalogItem item;
+
+  /// Creates an instance of [SubscriptionCard].
+  const SubscriptionCard({
+    required this.item,
+    super.key,
+  });
+
+  static const double _cardHeight = 276;
+
+  static int _monthsFromDuration(int durationDays) {
+    final months = durationDays ~/ 30;
+    return months < 1 ? 1 : months;
+  }
+
+  static String _monthsLabel(int value) {
+    final mod100 = value % 100;
+    if (mod100 >= 11 && mod100 <= 14) {
+      return 'месяцев';
+    }
+
+    return switch (value % 10) {
+      1 => 'месяц',
+      2 || 3 || 4 => 'месяца',
+      _ => 'месяцев',
+    };
+  }
+
+  static String _formatPrice(String value) {
+    final normalized = value.trim().replaceAll(',', '.');
+    final parsed = num.tryParse(normalized);
+    if (parsed == null) return value;
+    if (parsed == parsed.roundToDouble()) return parsed.toInt().toString();
+    return parsed.toString().replaceAll('.', ',');
+  }
+
+  static const List<String> _benefits = [
+    AppStrings.subscriptionsCatalogBenefitTests,
+    AppStrings.subscriptionsCatalogBenefitExercises,
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = AppTextTheme.of(context);
+    final colorTheme = AppColorTheme.of(context);
+    final months = _monthsFromDuration(item.durationDays);
+
+    return SizedBox(
+      height: 306,
+      child: Stack(
+        clipBehavior: Clip.none,
+        children: [
+          Align(
+            alignment: Alignment.bottomCenter,
+            child: AppCard(
+              height: _cardHeight,
+              contentPadding: const EdgeInsets.all(20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  Text(
+                    '${_formatPrice(item.price)} рублей',
+                    style: textTheme.bodyMedium.copyWith(
+                      fontSize: 16,
+                      height: 24 / 16,
+                      fontWeight: FontWeight.w600,
+                      color: colorTheme.onSurface,
+                    ),
+                  ),
+                  const SizedBox(height: 32),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: _benefits
+                        .map(
+                          (benefit) => Padding(
+                            padding: const EdgeInsets.only(bottom: 4),
+                            child: Row(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  '•',
+                                  style: textTheme.body.copyWith(
+                                    color: colorTheme.onSurface,
+                                  ),
+                                ),
+                                const SizedBox(width: 8),
+                                Expanded(
+                                  child: Text(
+                                    benefit,
+                                    style: textTheme.body.copyWith(
+                                      color: colorTheme.onSurface,
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        )
+                        .toList(),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          Positioned(
+            left: 20,
+            top: 0,
+            child: RichText(
+              text: TextSpan(
+                children: [
+                  TextSpan(
+                    text: '$months',
+                    style: textTheme.bodyMedium.copyWith(
+                      fontSize: 96,
+                      height: 0.85,
+                      fontWeight: FontWeight.w100,
+                      color: colorTheme.darkHint,
+                    ),
+                  ),
+                  TextSpan(
+                    text: ' ${_monthsLabel(months)}',
+                    style: textTheme.bodyMedium.copyWith(
+                      fontSize: 20,
+                      height: 30 / 20,
+                      fontWeight: FontWeight.w300,
+                      color: colorTheme.darkHint,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          Align(
+            alignment: Alignment.topRight,
+            child: NetworkImageWidget(
+              imageUrl: item.imageUrl,
+              height: 230,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/subscriptions/presentation/widgets/subscription_card.dart
+++ b/lib/features/subscriptions/presentation/widgets/subscription_card.dart
@@ -20,30 +20,26 @@ class SubscriptionCard extends StatelessWidget {
 
   static const double _cardHeight = 276;
 
-  static int _monthsFromDuration(int durationDays) {
-    final months = durationDays ~/ 30;
-    return months < 1 ? 1 : months;
-  }
-
-  static String _monthsLabel(int value) {
-    final mod100 = value % 100;
-    if (mod100 >= 11 && mod100 <= 14) {
-      return 'месяцев';
-    }
-
-    return switch (value % 10) {
-      1 => 'месяц',
-      2 || 3 || 4 => 'месяца',
-      _ => 'месяцев',
-    };
-  }
-
   static String _formatPrice(String value) {
     final normalized = value.trim().replaceAll(',', '.');
-    final parsed = num.tryParse(normalized);
-    if (parsed == null) return value;
-    if (parsed == parsed.roundToDouble()) return parsed.toInt().toString();
-    return parsed.toString().replaceAll('.', ',');
+    if (normalized.endsWith('.00')) {
+      return normalized.substring(0, normalized.length - 3);
+    }
+    return normalized.replaceAll('.', ',');
+  }
+
+  static ({String value, String unit}) _buildPeriodParts(String name) {
+    final match = RegExp(r'^\s*(\d+)\s+(.+?)\s*$').firstMatch(name);
+    if (match != null) {
+      return (
+        value: match.group(1)!,
+        unit: match.group(2)!,
+      );
+    }
+    return (
+      value: name.trim(),
+      unit: '',
+    );
   }
 
   static const List<String> _benefits = [
@@ -55,7 +51,7 @@ class SubscriptionCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final textTheme = AppTextTheme.of(context);
     final colorTheme = AppColorTheme.of(context);
-    final months = _monthsFromDuration(item.durationDays);
+    final period = _buildPeriodParts(item.name);
 
     return SizedBox(
       height: 306,
@@ -72,7 +68,7 @@ class SubscriptionCard extends StatelessWidget {
                 mainAxisAlignment: MainAxisAlignment.end,
                 children: [
                   Text(
-                    '${_formatPrice(item.price)} рублей',
+                    '${_formatPrice(item.price)} ${AppStrings.subscriptionsCatalogRubles}',
                     style: textTheme.bodyMedium.copyWith(
                       fontSize: 16,
                       height: 24 / 16,
@@ -122,7 +118,7 @@ class SubscriptionCard extends StatelessWidget {
               text: TextSpan(
                 children: [
                   TextSpan(
-                    text: '$months',
+                    text: period.value,
                     style: textTheme.bodyMedium.copyWith(
                       fontSize: 96,
                       height: 0.85,
@@ -131,7 +127,7 @@ class SubscriptionCard extends StatelessWidget {
                     ),
                   ),
                   TextSpan(
-                    text: ' ${_monthsLabel(months)}',
+                    text: period.unit.isEmpty ? '' : ' ${period.unit}',
                     style: textTheme.bodyMedium.copyWith(
                       fontSize: 20,
                       height: 30 / 20,
@@ -143,8 +139,9 @@ class SubscriptionCard extends StatelessWidget {
               ),
             ),
           ),
-          Align(
-            alignment: Alignment.topRight,
+          Positioned(
+            right: 0,
+            top: 0,
             child: NetworkImageWidget(
               imageUrl: item.imageUrl,
               height: 230,

--- a/lib/features/workouts/data/mappers/workout_image_url_mapper.dart
+++ b/lib/features/workouts/data/mappers/workout_image_url_mapper.dart
@@ -1,16 +1,4 @@
-import '../../../../core/network/api_paths.dart';
+import '../../../../core/network/mappers/image_url_mapper.dart';
 
 /// Normalizes relative backend workout image paths into absolute URLs.
-String normalizeWorkoutImageUrl(String rawImage) {
-  final image = rawImage.trim();
-  if (image.isEmpty) return '';
-  if (image.startsWith('http://') || image.startsWith('https://')) {
-    return image;
-  }
-
-  final normalizedPath = image.replaceFirst(RegExp(r'^/+'), '');
-  final storagePath = normalizedPath.startsWith('storage/')
-      ? normalizedPath
-      : 'storage/$normalizedPath';
-  return Uri.parse(ApiPaths.baseUrl).resolve(storagePath).toString();
-}
+String normalizeWorkoutImageUrl(String rawImage) => normalizeBackendImageUrl(rawImage);

--- a/lib/uikit/cards/app_card.dart
+++ b/lib/uikit/cards/app_card.dart
@@ -11,10 +11,14 @@ class AppCard extends StatelessWidget {
   /// Internal content padding.
   final EdgeInsetsGeometry contentPadding;
 
+  /// Optional card height.
+  final double? height;
+
   /// Creates an instance of [AppCard].
   const AppCard({
     required this.child,
     this.contentPadding = const EdgeInsets.symmetric(horizontal: 20, vertical: 18),
+    this.height,
     super.key,
   });
 
@@ -37,9 +41,12 @@ class AppCard extends StatelessWidget {
           color: colorTheme.surface,
           borderRadius: BorderRadius.circular(12),
         ),
-        child: Padding(
-          padding: contentPadding,
-          child: child,
+        child: SizedBox(
+          height: height,
+          child: Padding(
+            padding: contentPadding,
+            child: child,
+          ),
         ),
       ),
     );

--- a/test/features/subscriptions/data/repositories/subscriptions_repository_impl_test.dart
+++ b/test/features/subscriptions/data/repositories/subscriptions_repository_impl_test.dart
@@ -37,9 +37,26 @@ void main() {
         expect(result.isSuccess, isTrue);
         expect(result.success, expectedItems);
         expect(result.success!.first.imageUrl, expectedItems.first.imageUrl);
-        expect(result.success!.first.durationDays, 30);
+        expect(result.success!.first.name, '1 месяц');
 
         verify(apiClient.getSubscriptions()).called(1);
+        verifyNever(logger.e(any, any, any));
+        verifyNoMoreInteractions(apiClient);
+      });
+
+      test('filters out inactive subscriptions from the catalog payload', () async {
+        final responseDto = createSubscriptionsResponseDto(includeInactive: true);
+        final expectedItems = createSubscriptionCatalogItems();
+        when(apiClient.getSubscriptions()).thenAnswer((_) async => responseDto);
+
+        final result = await repository.getSubscriptions();
+
+        expect(result.isSuccess, isTrue);
+        expect(result.success, expectedItems);
+        expect(result.success!.any((item) => item.id == 3), isFalse);
+
+        verify(apiClient.getSubscriptions()).called(1);
+        verifyNever(logger.e(any, any, any));
         verifyNoMoreInteractions(apiClient);
       });
 
@@ -57,6 +74,7 @@ void main() {
         expect(result.failure!.parentException, exception);
 
         verify(apiClient.getSubscriptions()).called(1);
+        verifyNever(logger.e(any, any, any));
         verifyNoMoreInteractions(apiClient);
       });
 

--- a/test/features/subscriptions/data/repositories/subscriptions_repository_impl_test.dart
+++ b/test/features/subscriptions/data/repositories/subscriptions_repository_impl_test.dart
@@ -47,7 +47,6 @@ void main() {
         final exception = createSubscriptionsDioBadResponseException(
           path: '/subscriptions',
           statusCode: 500,
-          code: 'server_error',
         );
         when(apiClient.getSubscriptions()).thenThrow(exception);
 

--- a/test/features/subscriptions/data/repositories/subscriptions_repository_impl_test.dart
+++ b/test/features/subscriptions/data/repositories/subscriptions_repository_impl_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:moveup_flutter/core/failures/feature/subscriptions/subscriptions_failure.dart';
+import 'package:moveup_flutter/core/utils/logger/app_logger.dart';
+import 'package:moveup_flutter/features/subscriptions/data/remote/subscriptions_api_client.dart';
+import 'package:moveup_flutter/features/subscriptions/data/repositories/subscriptions_repository_impl.dart';
+import 'package:moveup_flutter/features/subscriptions/domain/repositories/subscriptions_repository.dart';
+
+import '../../support/subscriptions_dto_fixtures.dart';
+import 'subscriptions_repository_impl_test.mocks.dart';
+
+@GenerateNiceMocks([
+  MockSpec<AppLogger>(),
+  MockSpec<SubscriptionsApiClient>(),
+])
+void main() {
+  late MockAppLogger logger;
+  late MockSubscriptionsApiClient apiClient;
+  late SubscriptionsRepository repository;
+
+  setUp(() {
+    logger = MockAppLogger();
+    apiClient = MockSubscriptionsApiClient();
+    repository = SubscriptionsRepositoryImpl(logger, apiClient);
+  });
+
+  group('SubscriptionsRepositoryImpl', () {
+    group('SubscriptionsRepositoryImpl.getSubscriptions', () {
+      test('returns success(items) when api succeeds', () async {
+        final responseDto = createSubscriptionsResponseDto();
+        final expectedItems = createSubscriptionCatalogItems();
+        when(apiClient.getSubscriptions()).thenAnswer((_) async => responseDto);
+
+        final result = await repository.getSubscriptions();
+
+        expect(result.isSuccess, isTrue);
+        expect(result.success, expectedItems);
+        expect(result.success!.first.imageUrl, expectedItems.first.imageUrl);
+        expect(result.success!.first.durationDays, 30);
+
+        verify(apiClient.getSubscriptions()).called(1);
+        verifyNoMoreInteractions(apiClient);
+      });
+
+      test('returns SubscriptionsRequestFailure when api returns server error', () async {
+        final exception = createSubscriptionsDioBadResponseException(
+          path: '/subscriptions',
+          statusCode: 500,
+          code: 'server_error',
+        );
+        when(apiClient.getSubscriptions()).thenThrow(exception);
+
+        final result = await repository.getSubscriptions();
+
+        expect(result.isFailure, isTrue);
+        expect(result.failure, isA<SubscriptionsRequestFailure>());
+        expect(result.failure!.parentException, exception);
+
+        verify(apiClient.getSubscriptions()).called(1);
+        verifyNoMoreInteractions(apiClient);
+      });
+
+      test('returns UnknownSubscriptionsFailure when unexpected exception occurs', () async {
+        final exception = Exception('unexpected_error');
+        when(apiClient.getSubscriptions()).thenThrow(exception);
+
+        final result = await repository.getSubscriptions();
+
+        expect(result.isFailure, isTrue);
+        expect(result.failure, isA<UnknownSubscriptionsFailure>());
+        expect(result.failure!.parentException, exception);
+
+        verify(apiClient.getSubscriptions()).called(1);
+        verify(logger.e(any, exception, any)).called(1);
+        verifyNoMoreInteractions(apiClient);
+      });
+    });
+  });
+}

--- a/test/features/subscriptions/presentation/cubits/subscriptions_cubit_test.dart
+++ b/test/features/subscriptions/presentation/cubits/subscriptions_cubit_test.dart
@@ -1,0 +1,78 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:moveup_flutter/core/failures/feature/subscriptions/subscriptions_failure.dart';
+import 'package:moveup_flutter/core/result/result.dart';
+import 'package:moveup_flutter/features/subscriptions/domain/entities/subscription_catalog_item.dart';
+import 'package:moveup_flutter/features/subscriptions/domain/repositories/subscriptions_repository.dart';
+import 'package:moveup_flutter/features/subscriptions/presentation/cubits/subscriptions_cubit.dart';
+
+import '../../support/subscriptions_dto_fixtures.dart';
+import 'subscriptions_cubit_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<SubscriptionsRepository>()])
+void main() {
+  late MockSubscriptionsRepository repository;
+  late SubscriptionsCubit subscriptionsCubit;
+
+  final items = createSubscriptionCatalogItems();
+
+  setUp(() {
+    repository = MockSubscriptionsRepository();
+    subscriptionsCubit = SubscriptionsCubit(repository);
+    provideDummy<Result<List<SubscriptionCatalogItem>, SubscriptionsFailure>>(
+      Success<List<SubscriptionCatalogItem>, SubscriptionsFailure>(items),
+    );
+  });
+
+  group('SubscriptionsCubit', () {
+    const subscriptionsFailure = SubscriptionsRequestFailure('error_message');
+
+    blocTest<SubscriptionsCubit, SubscriptionsState>(
+      'emits inProgress only once when loadSubscriptions is called twice',
+      setUp: () => when(repository.getSubscriptions()).thenAnswer(
+        (_) async => Success<List<SubscriptionCatalogItem>, SubscriptionsFailure>(items),
+      ),
+      build: () => subscriptionsCubit,
+      act: (cubit) {
+        cubit.loadSubscriptions();
+        cubit.loadSubscriptions();
+      },
+      expect: () => [
+        const SubscriptionsState.inProgress(),
+        SubscriptionsState.loaded(items),
+      ],
+      verify: (_) => verify(repository.getSubscriptions()).called(1),
+    );
+
+    blocTest<SubscriptionsCubit, SubscriptionsState>(
+      'emits loaded(items) when loadSubscriptions succeeds',
+      setUp: () => when(repository.getSubscriptions()).thenAnswer(
+        (_) async => Success<List<SubscriptionCatalogItem>, SubscriptionsFailure>(items),
+      ),
+      build: () => subscriptionsCubit,
+      act: (cubit) => cubit.loadSubscriptions(),
+      expect: () => [
+        const SubscriptionsState.inProgress(),
+        SubscriptionsState.loaded(items),
+      ],
+      verify: (_) => verify(repository.getSubscriptions()).called(1),
+    );
+
+    blocTest<SubscriptionsCubit, SubscriptionsState>(
+      'emits failed(subscriptionsFailure) when loadSubscriptions fails',
+      setUp: () => when(repository.getSubscriptions()).thenAnswer(
+        (_) async =>
+            const Failure<List<SubscriptionCatalogItem>, SubscriptionsFailure>(subscriptionsFailure),
+      ),
+      build: () => subscriptionsCubit,
+      act: (cubit) => cubit.loadSubscriptions(),
+      expect: () => const [
+        SubscriptionsState.inProgress(),
+        SubscriptionsState.failed(subscriptionsFailure),
+      ],
+      verify: (_) => verify(repository.getSubscriptions()).called(1),
+    );
+  });
+}

--- a/test/features/subscriptions/support/subscriptions_dto_fixtures.dart
+++ b/test/features/subscriptions/support/subscriptions_dto_fixtures.dart
@@ -1,0 +1,69 @@
+import 'package:dio/dio.dart';
+import 'package:moveup_flutter/core/network/api_paths.dart';
+import 'package:moveup_flutter/features/subscriptions/data/dto/subscription_catalog_item_dto.dart';
+import 'package:moveup_flutter/features/subscriptions/data/dto/subscriptions_response_dto.dart';
+import 'package:moveup_flutter/features/subscriptions/domain/entities/subscription_catalog_item.dart';
+
+/// Test fixture for subscriptions response DTO.
+SubscriptionsResponseDto createSubscriptionsResponseDto() => SubscriptionsResponseDto(
+  data: [
+    SubscriptionCatalogItemDto(
+      id: 1,
+      name: '1 месяц',
+      description: 'Полный доступ к тренировкам на один месяц',
+      image: '/subscriptions/subscription.png',
+      price: '550.00',
+      durationDays: '30',
+      isActive: true,
+    ),
+    SubscriptionCatalogItemDto(
+      id: 2,
+      name: '3 месяца',
+      description: 'Полный доступ к тренировкам на три месяца',
+      image: 'http://localhost:8000/storage/subscriptions/subscription-3.png',
+      price: '1400.00',
+      durationDays: '90',
+      isActive: true,
+    ),
+  ],
+);
+
+/// Test fixture for subscriptions domain entities.
+List<SubscriptionCatalogItem> createSubscriptionCatalogItems() => [
+  SubscriptionCatalogItem(
+    id: 1,
+    description: 'Полный доступ к тренировкам на один месяц',
+    price: '550.00',
+    durationDays: 30,
+    imageUrl: Uri.parse(ApiPaths.baseUrl).resolve('storage/subscriptions/subscription.png').toString(),
+  ),
+  const SubscriptionCatalogItem(
+    id: 2,
+    description: 'Полный доступ к тренировкам на три месяца',
+    price: '1400.00',
+    durationDays: 90,
+    imageUrl: 'http://localhost:8000/storage/subscriptions/subscription-3.png',
+  ),
+];
+
+/// Creates a bad-response [DioException] for subscriptions API tests.
+DioException createSubscriptionsDioBadResponseException({
+  required String path,
+  required int statusCode,
+  String code = 'server_error',
+}) {
+  final requestOptions = RequestOptions(path: path);
+  return DioException(
+    requestOptions: requestOptions,
+    response: Response<Map<String, dynamic>>(
+      requestOptions: requestOptions,
+      statusCode: statusCode,
+      data: {
+        'success': false,
+        'message': 'error',
+        'code': code,
+      },
+    ),
+    type: DioExceptionType.badResponse,
+  );
+}

--- a/test/features/subscriptions/support/subscriptions_dto_fixtures.dart
+++ b/test/features/subscriptions/support/subscriptions_dto_fixtures.dart
@@ -13,7 +13,7 @@ SubscriptionsResponseDto createSubscriptionsResponseDto() => SubscriptionsRespon
       description: 'Полный доступ к тренировкам на один месяц',
       image: '/subscriptions/subscription.png',
       price: '550.00',
-      durationDays: '30',
+      durationDays: 30,
       isActive: true,
     ),
     SubscriptionCatalogItemDto(
@@ -22,7 +22,7 @@ SubscriptionsResponseDto createSubscriptionsResponseDto() => SubscriptionsRespon
       description: 'Полный доступ к тренировкам на три месяца',
       image: 'http://localhost:8000/storage/subscriptions/subscription-3.png',
       price: '1400.00',
-      durationDays: '90',
+      durationDays: 90,
       isActive: true,
     ),
   ],
@@ -32,6 +32,7 @@ SubscriptionsResponseDto createSubscriptionsResponseDto() => SubscriptionsRespon
 List<SubscriptionCatalogItem> createSubscriptionCatalogItems() => [
   SubscriptionCatalogItem(
     id: 1,
+    name: '1 месяц',
     description: 'Полный доступ к тренировкам на один месяц',
     price: '550.00',
     durationDays: 30,
@@ -39,6 +40,7 @@ List<SubscriptionCatalogItem> createSubscriptionCatalogItems() => [
   ),
   const SubscriptionCatalogItem(
     id: 2,
+    name: '3 месяца',
     description: 'Полный доступ к тренировкам на три месяца',
     price: '1400.00',
     durationDays: 90,

--- a/test/features/subscriptions/support/subscriptions_dto_fixtures.dart
+++ b/test/features/subscriptions/support/subscriptions_dto_fixtures.dart
@@ -5,8 +5,8 @@ import 'package:moveup_flutter/features/subscriptions/data/dto/subscriptions_res
 import 'package:moveup_flutter/features/subscriptions/domain/entities/subscription_catalog_item.dart';
 
 /// Test fixture for subscriptions response DTO.
-SubscriptionsResponseDto createSubscriptionsResponseDto() => SubscriptionsResponseDto(
-  data: [
+SubscriptionsResponseDto createSubscriptionsResponseDto({bool includeInactive = false}) {
+  final data = [
     SubscriptionCatalogItemDto(
       id: 1,
       name: '1 месяц',
@@ -25,8 +25,24 @@ SubscriptionsResponseDto createSubscriptionsResponseDto() => SubscriptionsRespon
       durationDays: 90,
       isActive: true,
     ),
-  ],
-);
+  ];
+
+  if (includeInactive) {
+    data.add(
+      SubscriptionCatalogItemDto(
+        id: 3,
+        name: '6 месяцев',
+        description: 'Архивный тариф',
+        image: '/subscriptions/subscription-archived.png',
+        price: '2500.00',
+        durationDays: 180,
+        isActive: false,
+      ),
+    );
+  }
+
+  return SubscriptionsResponseDto(data: data);
+}
 
 /// Test fixture for subscriptions domain entities.
 List<SubscriptionCatalogItem> createSubscriptionCatalogItems() => [
@@ -35,7 +51,6 @@ List<SubscriptionCatalogItem> createSubscriptionCatalogItems() => [
     name: '1 месяц',
     description: 'Полный доступ к тренировкам на один месяц',
     price: '550.00',
-    durationDays: 30,
     imageUrl: Uri.parse(ApiPaths.baseUrl).resolve('storage/subscriptions/subscription.png').toString(),
   ),
   const SubscriptionCatalogItem(
@@ -43,7 +58,6 @@ List<SubscriptionCatalogItem> createSubscriptionCatalogItems() => [
     name: '3 месяца',
     description: 'Полный доступ к тренировкам на три месяца',
     price: '1400.00',
-    durationDays: 90,
     imageUrl: 'http://localhost:8000/storage/subscriptions/subscription-3.png',
   ),
 ];


### PR DESCRIPTION
## 🚀 Summary

Implemented the authenticated subscriptions catalog flow end-to-end, adding a dedicated `/subscriptions` screen with repository-backed loading, branded catalog cards, and a direct entry button from `/profile`. The feature introduces a standalone `subscriptions` slice on the same architectural pattern as workouts/tests, while keeping the UI ready for future subscription details work by preserving both normalized catalog fields and the original backend `name`.

## ✨ Changes

- ✅ Added `GET /api/subscriptions` contract through `SubscriptionsApiClient`, subscriptions DTOs, and route wiring for the new authenticated `/subscriptions` screen
- ✅ Added `SubscriptionsFailure`, `SubscriptionCatalogItem`, `SubscriptionsRepository`, and `SubscriptionsRepositoryImpl` with image URL normalization and subscriptions-specific error mapping
- ✅ Added repository test coverage for subscriptions catalog success, request failure, unexpected failure, and normalized image mapping
- ✅ Added `SubscriptionsCubit` + state with single-submit guard for catalog loading
- ✅ Added cubit test coverage for `SubscriptionsCubit` success, failure, and repeated-load protection
- ✅ Added `SubscriptionsCatalogPageBuilder`, `SubscriptionsCatalogPage`, and `SubscriptionCard` based on the provided mockup, including decorative background figures, fixed-height card support, and branded subscription catalog layout
- ✅ Added a profile CTA button between statistics and current phase that opens the subscriptions catalog through `context.push(AppRoutePaths.subscriptionsCatalogPath)`
- ✅ Extended shared `AppCard` with an optional fixed `height` so the subscriptions catalog can match the required card proportions without forking the card component
- ✅ Preserved both `name` and `durationDays` in `SubscriptionCatalogItem`, so the current catalog can render from structured duration data while future profile/details flows can still reuse the backend subscription title

## 🧪 Verification

- [x] `flutter analyze`
- [x] `flutter test test/features/subscriptions`
- [x] `flutter test test/features/profile`
