### PR TITLE
 feat(profile): implement profile subscription section 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Profile current phase section for the authenticated `/profile` tab, reusing the bootstrap profile phase snapshot plus aggregate statistics frequency summary to render the read-only phase block without a standalone phase slice.
 - Introduce personal parameters section for the authenticated `/profile` tab, including canonical `user-parameters` read/update flow, editable profile form card, weekly-goal save support, and selective workouts overview refresh when goal, equipment, or level changes regenerate the personal plan.
 - Add profile bottom section for the authenticated `/profile` tab, including logout and delete-profile confirmation actions plus direct links to the bundled legal documents.
+- Profile subscription section for the authenticated `/profile` tab, including active and empty subscription states, catalog entrypoints, profile-local subscription card hydration by `subscriptionId`, cancel-subscription confirmation flow and profile page refresh after cancellation.
 - Authenticated subscriptions catalog screen, including dedicated subscriptions route, catalog Cubit, card UI with normalized remote images, and a profile CTA for opening available subscription plans.
 - Authenticated subscription details and payment flow, including a dedicated details route, catalog-backed item resolution, manual-card payment dialog, and redirect to `/profile` after successful purchase.
 

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -337,6 +337,21 @@ abstract final class AppStrings {
   static const profileBottomDeleteTitle = 'Вы уверены, что хотите удалить профиль?';
   static const profileBottomDeleteConfirm = 'Удалить';
   static const profileSubscriptionsButton = 'Выбрать подписку';
+  static const profileSubscriptionActiveTitleAccent = 'Срок действия';
+  static const profileSubscriptionActiveTitleSuffix = ' вашей подписки';
+  static const profileSubscriptionExpiryPrefix = 'до';
+  static const profileSubscriptionRenewButton = 'Продлить подписку';
+  static const profileSubscriptionCancelButton = 'Отменить подписку';
+  static const profileSubscriptionCancelTitle = 'Отменить подписку?';
+  static const profileSubscriptionCancelDescription = 'Вы действительно хотите отменить подписку?';
+  static const profileSubscriptionCancelConfirm = 'Подтвердить';
+  static const profileSubscriptionEmptyTitle = 'У Вас нет активной подписки';
+  static const profileSubscriptionEmptySubtitle = 'Оформите подписку и получите:';
+  static const profileSubscriptionBenefitTrainings = 'Полный доступ к персональным тренировкам';
+  static const profileSubscriptionBenefitTestsAndExercises =
+      'Расширенный набор тестов и упражнений';
+  static const profileSubscriptionCardLoadFailed = 'Не удалось загрузить подписку';
+  static const profileSubscriptionCardRetryButton = 'Повторить';
   static const profileStatsTitle = 'Статистика тренировок пользователя';
   static const profileStatsHistoryButton = 'История';
   static const profileStatsVolumeMode = 'Объём';

--- a/lib/core/di/di.dart
+++ b/lib/core/di/di.dart
@@ -26,6 +26,7 @@ import '../../features/profile/data/repositories/profile_statistics_repository_i
 import '../../features/profile/domain/repositories/profile_parameters_repository.dart';
 import '../../features/profile/domain/repositories/profile_repository.dart';
 import '../../features/profile/domain/repositories/profile_statistics_repository.dart';
+import '../../features/profile/presentation/cubits/profile_refresh_cubit.dart';
 import '../../features/subscriptions/data/remote/subscriptions_api_client.dart';
 import '../../features/subscriptions/data/remote/subscription_payment_api_client.dart';
 import '../../features/subscriptions/data/repositories/subscriptions_repository_impl.dart';
@@ -138,6 +139,10 @@ Future<void> setupDI() async {
       di<AppLogger>(),
       di<ProfileApiClient>(),
     ),
+  );
+  di.registerLazySingleton<ProfileRefreshCubit>(
+    () => ProfileRefreshCubit(),
+    dispose: (cubit) => cubit.close(),
   );
   di.registerLazySingleton<ProfileStatisticsRepository>(
     () => ProfileStatisticsRepositoryImpl(

--- a/lib/core/network/api_paths.dart
+++ b/lib/core/network/api_paths.dart
@@ -107,6 +107,9 @@ abstract class ApiPaths {
   /// The endpoint for the subscriptions catalog.
   static const String subscriptions = '${apiPrefix}subscriptions';
 
+  /// The endpoint for cancelling the active subscription.
+  static const String cancelSubscription = '${apiPrefix}cancel-subscription';
+
   /// The endpoint for paying for a subscription.
   static const String paymentSubscription = '${apiPrefix}payment/subscription';
 

--- a/lib/core/router/router.dart
+++ b/lib/core/router/router.dart
@@ -23,9 +23,9 @@ import '../../features/offline/presentation/pages/offline_page.dart';
 import '../../features/profile/presentation/pages/profile_page_builder.dart';
 import '../../features/root/presentation/pages/root_screen.dart';
 import '../../features/splash/presentation/pages/splash_page.dart';
+import '../../features/subscriptions/domain/entities/subscription_catalog_item.dart';
 import '../../features/subscriptions/presentation/pages/subscriptions_catalog_page_builder.dart';
 import '../../features/subscriptions/presentation/pages/subscriptions_details_page_builder.dart';
-import '../../features/subscriptions/domain/entities/subscription_catalog_item.dart';
 import '../../features/tests/attempt/presentation/pages/tests_attempt_page_builder.dart';
 import '../../features/tests/catalog/presentation/pages/tests_catalog_page_builder.dart';
 import '../../features/workouts/details/presentation/pages/workout_details_page_builder.dart';
@@ -290,7 +290,9 @@ final router = GoRouter(
           },
           builder: (_, state) => SubscriptionsDetailsPageBuilder(
             subscriptionId: int.parse(state.pathParameters['subscriptionId']!),
-            seedItem: state.extra is SubscriptionCatalogItem ? state.extra as SubscriptionCatalogItem : null,
+            seedItem: state.extra is SubscriptionCatalogItem
+                ? state.extra as SubscriptionCatalogItem
+                : null,
           ),
         ),
       ],

--- a/lib/features/profile/presentation/cubits/profile_refresh_cubit.dart
+++ b/lib/features/profile/presentation/cubits/profile_refresh_cubit.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'profile_refresh_cubit.freezed.dart';
+part 'profile_refresh_state.dart';
+
+/// Shared trigger for refreshing `/profile` after external flows mutate its data.
+final class ProfileRefreshCubit extends Cubit<ProfileRefreshState> {
+  /// Creates an instance of [ProfileRefreshCubit].
+  ProfileRefreshCubit() : super(const ProfileRefreshState());
+
+  /// Marks the profile as needing a refresh.
+  void requestRefresh() {
+    if (state.shouldRefresh) return;
+    emit(const ProfileRefreshState(shouldRefresh: true));
+  }
+
+  /// Clears the pending refresh request after the UI handled it.
+  void consumeRefreshRequest() {
+    if (!state.shouldRefresh) return;
+    emit(const ProfileRefreshState());
+  }
+}

--- a/lib/features/profile/presentation/cubits/profile_refresh_state.dart
+++ b/lib/features/profile/presentation/cubits/profile_refresh_state.dart
@@ -1,0 +1,10 @@
+part of 'profile_refresh_cubit.dart';
+
+/// State for [ProfileRefreshCubit].
+@freezed
+abstract class ProfileRefreshState with _$ProfileRefreshState {
+  /// Creates an instance of [ProfileRefreshState].
+  const factory ProfileRefreshState({
+    @Default(false) bool shouldRefresh,
+  }) = _ProfileRefreshState;
+}

--- a/lib/features/profile/presentation/cubits/profile_subscription_cubit.dart
+++ b/lib/features/profile/presentation/cubits/profile_subscription_cubit.dart
@@ -1,0 +1,143 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../../../../core/failures/feature/subscriptions/subscriptions_failure.dart';
+import '../../../../../core/result/result.dart';
+import '../../../subscriptions/domain/entities/subscription_catalog_item.dart';
+import '../../../subscriptions/domain/repositories/subscriptions_repository.dart';
+import '../../domain/entities/profile_stats_history_snapshot.dart';
+
+part 'profile_subscription_cubit.freezed.dart';
+part 'profile_subscription_state.dart';
+
+/// Orchestrates the profile-local active subscription section state.
+///
+/// `/profile` exposes the active user-subscription record, not the catalog
+/// subscription id, so the card is resolved from the active catalog by
+/// matching business fields like name and price.
+final class ProfileSubscriptionCubit extends Cubit<ProfileSubscriptionState> {
+  final SubscriptionsRepository _repository;
+
+  /// Creates an instance of [ProfileSubscriptionCubit].
+  ProfileSubscriptionCubit(this._repository) : super(const ProfileSubscriptionState());
+
+  /// Synchronizes the current profile active subscription snapshot with the section.
+  Future<void> syncActiveSubscription(
+    ProfileActiveSubscriptionSnapshot? activeSubscription,
+  ) async {
+    final currentActiveSubscription = state.activeSubscription;
+    final currentSubscriptionId = currentActiveSubscription?.id;
+    final nextSubscriptionId = activeSubscription?.id;
+
+    if (activeSubscription == null) {
+      emit(const ProfileSubscriptionState());
+      return;
+    }
+
+    if (currentSubscriptionId == nextSubscriptionId) {
+      if (currentActiveSubscription != activeSubscription) {
+        emit(state.copyWith(activeSubscription: activeSubscription));
+      }
+      return;
+    }
+
+    emit(
+      state.copyWith(
+        isLoading: true,
+        activeSubscription: activeSubscription,
+        item: null,
+        failure: null,
+      ),
+    );
+
+    await _loadSubscription();
+  }
+
+  /// Retries loading the active subscription card data.
+  Future<void> retry() async {
+    final activeSubscription = state.activeSubscription;
+    if (activeSubscription == null || state.isLoading) return;
+
+    emit(
+      state.copyWith(
+        isLoading: true,
+        failure: null,
+      ),
+    );
+
+    await _loadSubscription();
+  }
+
+  Future<void> _loadSubscription() async {
+    final activeSubscription = state.activeSubscription;
+    if (activeSubscription == null) {
+      emit(const ProfileSubscriptionState());
+      return;
+    }
+
+    final result = await _repository.getSubscriptions();
+    if (isClosed) return;
+
+    switch (result) {
+      case Success(:final data):
+        final item = _findMatchingItem(
+          data,
+          activeSubscription: activeSubscription,
+        );
+        if (item == null) {
+          emit(
+            state.copyWith(
+              isLoading: false,
+              item: null,
+              failure: const SubscriptionsNotFoundFailure(),
+            ),
+          );
+          return;
+        }
+        emit(
+          state.copyWith(
+            isLoading: false,
+            item: item,
+            failure: null,
+          ),
+        );
+      case Failure(:final error):
+        emit(
+          state.copyWith(
+            isLoading: false,
+            item: null,
+            failure: error,
+          ),
+        );
+    }
+  }
+
+  SubscriptionCatalogItem? _findMatchingItem(
+    List<SubscriptionCatalogItem> items, {
+    required ProfileActiveSubscriptionSnapshot activeSubscription,
+  }) {
+    final normalizedName = _normalizeName(activeSubscription.name);
+
+    for (final item in items) {
+      if (_normalizeName(item.name) != normalizedName) continue;
+      if (_pricesEqual(item.price, activeSubscription.price)) return item;
+    }
+
+    for (final item in items) {
+      if (_normalizeName(item.name) == normalizedName) return item;
+    }
+
+    return null;
+  }
+
+  String _normalizeName(String value) => value.trim().toLowerCase();
+
+  bool _pricesEqual(String left, String right) {
+    final leftValue = num.tryParse(left.trim().replaceAll(',', '.'));
+    final rightValue = num.tryParse(right.trim().replaceAll(',', '.'));
+    if (leftValue != null && rightValue != null) {
+      return leftValue == rightValue;
+    }
+    return left.trim() == right.trim();
+  }
+}

--- a/lib/features/profile/presentation/cubits/profile_subscription_state.dart
+++ b/lib/features/profile/presentation/cubits/profile_subscription_state.dart
@@ -1,0 +1,13 @@
+part of 'profile_subscription_cubit.dart';
+
+/// State for [ProfileSubscriptionCubit].
+@freezed
+abstract class ProfileSubscriptionState with _$ProfileSubscriptionState {
+  /// Creates an instance of [ProfileSubscriptionState].
+  const factory ProfileSubscriptionState({
+    @Default(false) bool isLoading,
+    ProfileActiveSubscriptionSnapshot? activeSubscription,
+    SubscriptionCatalogItem? item,
+    SubscriptionsFailure? failure,
+  }) = _ProfileSubscriptionState;
+}

--- a/lib/features/profile/presentation/pages/profile_page.dart
+++ b/lib/features/profile/presentation/pages/profile_page.dart
@@ -15,6 +15,7 @@ import '../../../../../uikit/themes/text/app_text_theme.dart';
 import '../../../auth/domain/entities/user.dart';
 import '../../../auth/presentation/cubits/auth_session_cubit.dart';
 import '../cubits/profile_parameters_cubit.dart';
+import '../cubits/profile_refresh_cubit.dart';
 import '../cubits/profile_statistics_cubit.dart';
 import '../cubits/profile_user_cubit.dart';
 import '../widgets/change_password_dialog.dart';
@@ -72,18 +73,30 @@ class ProfilePage extends StatelessWidget {
           ),
         ],
       ),
-      body: BlocListener<ProfileUserCubit, ProfileUserState>(
-        listenWhen: (previous, current) =>
-            previous.historySnapshot != current.historySnapshot ||
-            previous.parametersSnapshot != current.parametersSnapshot,
-        listener: (context, state) {
-          final historySnapshot = state.historySnapshot;
-          if (historySnapshot != null) {
-            context.read<ProfileStatisticsCubit>().setHistorySnapshot(historySnapshot);
-          }
+      body: MultiBlocListener(
+        listeners: [
+          BlocListener<ProfileRefreshCubit, ProfileRefreshState>(
+            listenWhen: (previous, current) => previous.shouldRefresh != current.shouldRefresh,
+            listener: (context, state) {
+              if (!state.shouldRefresh) return;
+              context.read<ProfileRefreshCubit>().consumeRefreshRequest();
+              unawaited(context.read<ProfileUserCubit>().refresh());
+            },
+          ),
+          BlocListener<ProfileUserCubit, ProfileUserState>(
+            listenWhen: (previous, current) =>
+                previous.historySnapshot != current.historySnapshot ||
+                previous.parametersSnapshot != current.parametersSnapshot,
+            listener: (context, state) {
+              final historySnapshot = state.historySnapshot;
+              if (historySnapshot != null) {
+                context.read<ProfileStatisticsCubit>().setHistorySnapshot(historySnapshot);
+              }
 
-          context.read<ProfileParametersCubit>().setBootstrapSnapshot(state.parametersSnapshot);
-        },
+              context.read<ProfileParametersCubit>().setBootstrapSnapshot(state.parametersSnapshot);
+            },
+          ),
+        ],
         child: BlocBuilder<ProfileUserCubit, ProfileUserState>(
           builder: (context, state) {
             final user = state.user;

--- a/lib/features/profile/presentation/pages/profile_page.dart
+++ b/lib/features/profile/presentation/pages/profile_page.dart
@@ -22,6 +22,7 @@ import '../widgets/current_phase_section_widget.dart';
 import '../widgets/edit_profile_dialog.dart';
 import '../widgets/profile_bottom_section_widget.dart';
 import '../widgets/profile_parameters_section_widget.dart';
+import '../widgets/profile_subscription_section_widget.dart';
 import '../widgets/stats/profile_history_dialog.dart';
 import '../widgets/stats/stats_section_widget.dart';
 import '../widgets/user_section_widget.dart';
@@ -119,12 +120,11 @@ class ProfilePage extends StatelessWidget {
                     onPressed: () => _openHistoryDialog(context),
                     child: const Text(AppStrings.profileStatsHistoryButton),
                   ),
-                  const SizedBox(height: 24),
-                  MainButton(
-                    onPressed: () => context.push(AppRoutePaths.subscriptionsCatalogPath),
-                    child: const Text(AppStrings.profileSubscriptionsButton),
+                  const SizedBox(height: 36),
+                  ProfileSubscriptionSectionWidget(
+                    activeSubscription: state.historySnapshot?.activeSubscription,
                   ),
-                  const SizedBox(height: 24),
+                  const SizedBox(height: 36),
                   const CurrentPhaseSectionWidget(),
                   const SizedBox(height: 36),
                   const ProfileParametersSectionWidget(),

--- a/lib/features/profile/presentation/pages/profile_page_builder.dart
+++ b/lib/features/profile/presentation/pages/profile_page_builder.dart
@@ -13,6 +13,7 @@ import '../../domain/repositories/profile_repository.dart';
 import '../../domain/repositories/profile_statistics_repository.dart';
 import '../cubits/delete_profile_cubit.dart';
 import '../cubits/profile_parameters_cubit.dart';
+import '../cubits/profile_refresh_cubit.dart';
 import '../cubits/profile_subscription_cubit.dart';
 import '../cubits/profile_statistics_cubit.dart';
 import '../cubits/profile_user_cubit.dart';
@@ -53,6 +54,9 @@ class ProfilePageBuilder extends StatelessWidget {
           create: (_) => ProfileSubscriptionCubit(
             di<SubscriptionsRepository>(),
           ),
+        ),
+        BlocProvider.value(
+          value: di<ProfileRefreshCubit>(),
         ),
         BlocProvider(
           create: (_) => LogoutCubit(di<AuthRepository>()),

--- a/lib/features/profile/presentation/pages/profile_page_builder.dart
+++ b/lib/features/profile/presentation/pages/profile_page_builder.dart
@@ -6,11 +6,14 @@ import '../../../auth/domain/entities/user.dart';
 import '../../../auth/domain/repositories/auth_repository.dart';
 import '../../../auth/presentation/cubits/auth_session_cubit.dart';
 import '../../../auth/presentation/cubits/logout_cubit.dart';
+import '../../../subscriptions/domain/repositories/subscriptions_repository.dart';
+import '../../../subscriptions/presentation/cubits/cancel_subscription_cubit.dart';
 import '../../domain/repositories/profile_parameters_repository.dart';
 import '../../domain/repositories/profile_repository.dart';
 import '../../domain/repositories/profile_statistics_repository.dart';
 import '../cubits/delete_profile_cubit.dart';
 import '../cubits/profile_parameters_cubit.dart';
+import '../cubits/profile_subscription_cubit.dart';
 import '../cubits/profile_statistics_cubit.dart';
 import '../cubits/profile_user_cubit.dart';
 import 'profile_page.dart';
@@ -47,10 +50,18 @@ class ProfilePageBuilder extends StatelessWidget {
           )..loadInitial(),
         ),
         BlocProvider(
+          create: (_) => ProfileSubscriptionCubit(
+            di<SubscriptionsRepository>(),
+          ),
+        ),
+        BlocProvider(
           create: (_) => LogoutCubit(di<AuthRepository>()),
         ),
         BlocProvider(
           create: (_) => DeleteProfileCubit(di<ProfileRepository>()),
+        ),
+        BlocProvider(
+          create: (_) => CancelSubscriptionCubit(di<SubscriptionsRepository>()),
         ),
       ],
       child: const ProfilePage(),

--- a/lib/features/profile/presentation/widgets/profile_subscription_section_widget.dart
+++ b/lib/features/profile/presentation/widgets/profile_subscription_section_widget.dart
@@ -17,8 +17,8 @@ import '../../../subscriptions/domain/entities/subscription_catalog_item.dart';
 import '../../../subscriptions/presentation/cubits/cancel_subscription_cubit.dart';
 import '../../../subscriptions/presentation/widgets/subscription_card.dart';
 import '../../domain/entities/profile_stats_history_snapshot.dart';
+import '../cubits/profile_refresh_cubit.dart';
 import '../cubits/profile_subscription_cubit.dart';
-import '../cubits/profile_user_cubit.dart';
 
 /// Subscription section rendered inside `/profile`.
 class ProfileSubscriptionSectionWidget extends StatefulWidget {
@@ -135,7 +135,7 @@ class _ProfileSubscriptionSectionWidgetState extends State<ProfileSubscriptionSe
         state.whenOrNull(
           succeed: () {
             _closeActiveDialog();
-            unawaited(context.read<ProfileUserCubit>().refresh());
+            context.read<ProfileRefreshCubit>().requestRefresh();
           },
           failed: (failure) {
             _closeActiveDialog();

--- a/lib/features/profile/presentation/widgets/profile_subscription_section_widget.dart
+++ b/lib/features/profile/presentation/widgets/profile_subscription_section_widget.dart
@@ -1,0 +1,440 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../../core/constants/app_strings.dart';
+import '../../../../../core/router/router_paths.dart';
+import '../../../../../uikit/buttons/button_state.dart';
+import '../../../../../uikit/buttons/main_button.dart';
+import '../../../../../uikit/buttons/secondary_button.dart';
+import '../../../../../uikit/dialogs/app_action_dialog.dart';
+import '../../../../../uikit/dialogs/app_feedback_dialog.dart';
+import '../../../../../uikit/themes/colors/app_color_theme.dart';
+import '../../../../../uikit/themes/text/app_text_theme.dart';
+import '../../../subscriptions/domain/entities/subscription_catalog_item.dart';
+import '../../../subscriptions/presentation/cubits/cancel_subscription_cubit.dart';
+import '../../../subscriptions/presentation/widgets/subscription_card.dart';
+import '../../domain/entities/profile_stats_history_snapshot.dart';
+import '../cubits/profile_subscription_cubit.dart';
+import '../cubits/profile_user_cubit.dart';
+
+/// Subscription section rendered inside `/profile`.
+class ProfileSubscriptionSectionWidget extends StatefulWidget {
+  /// Active subscription snapshot from the canonical `/profile` payload.
+  final ProfileActiveSubscriptionSnapshot? activeSubscription;
+
+  /// Creates an instance of [ProfileSubscriptionSectionWidget].
+  const ProfileSubscriptionSectionWidget({
+    required this.activeSubscription,
+    super.key,
+  });
+
+  @override
+  State<ProfileSubscriptionSectionWidget> createState() => _ProfileSubscriptionSectionWidgetState();
+}
+
+class _ProfileSubscriptionSectionWidgetState extends State<ProfileSubscriptionSectionWidget> {
+  bool _isCancelDialogOpen = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _syncActiveSubscription();
+  }
+
+  @override
+  void didUpdateWidget(covariant ProfileSubscriptionSectionWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.activeSubscription == widget.activeSubscription) return;
+    _syncActiveSubscription();
+  }
+
+  void _syncActiveSubscription() {
+    unawaited(
+      context.read<ProfileSubscriptionCubit>().syncActiveSubscription(widget.activeSubscription),
+    );
+  }
+
+  void _openCatalog() {
+    unawaited(context.push(AppRoutePaths.subscriptionsCatalogPath));
+  }
+
+  void _showCancelDialog() {
+    unawaited(_openCancelDialog());
+  }
+
+  Future<void> _openCancelDialog() async {
+    if (_isCancelDialogOpen) return;
+    _isCancelDialogOpen = true;
+    final cancelCubit = context.read<CancelSubscriptionCubit>();
+    try {
+      await showAppActionDialog(
+        context,
+        title: AppStrings.profileSubscriptionCancelTitle,
+        description: AppStrings.profileSubscriptionCancelDescription,
+        primaryAction: BlocProvider.value(
+          value: cancelCubit,
+          child: BlocBuilder<CancelSubscriptionCubit, CancelSubscriptionState>(
+            builder: (context, state) {
+              final isInProgress = state.maybeWhen(
+                inProgress: () => true,
+                orElse: () => false,
+              );
+              return MainButton(
+                state: isInProgress ? ButtonState.loading : ButtonState.enabled,
+                onPressed: () => context.read<CancelSubscriptionCubit>().cancelSubscription(),
+                child: const Text(AppStrings.profileSubscriptionCancelConfirm),
+              );
+            },
+          ),
+        ),
+        secondaryAction: BlocProvider.value(
+          value: cancelCubit,
+          child: BlocBuilder<CancelSubscriptionCubit, CancelSubscriptionState>(
+            builder: (context, state) {
+              final isInProgress = state.maybeWhen(
+                inProgress: () => true,
+                orElse: () => false,
+              );
+              return SecondaryButton(
+                state: isInProgress ? ButtonState.disabled : ButtonState.enabled,
+                onPressed: _closeActiveDialog,
+                child: const Text(AppStrings.profileCancelButton),
+              );
+            },
+          ),
+        ),
+      );
+    } finally {
+      _isCancelDialogOpen = false;
+    }
+  }
+
+  void _closeActiveDialog() {
+    final navigator = Navigator.of(context, rootNavigator: true);
+    if (!navigator.canPop()) return;
+
+    Route<dynamic>? topRoute;
+    navigator.popUntil((route) {
+      topRoute = route;
+      return true;
+    });
+    if (topRoute is! PopupRoute<dynamic>) return;
+
+    navigator.pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final activeSubscription = widget.activeSubscription;
+
+    return BlocListener<CancelSubscriptionCubit, CancelSubscriptionState>(
+      listener: (context, state) {
+        state.whenOrNull(
+          succeed: () {
+            _closeActiveDialog();
+            unawaited(context.read<ProfileUserCubit>().refresh());
+          },
+          failed: (failure) {
+            _closeActiveDialog();
+            if (failure.message.isEmpty) return;
+            unawaited(
+              showAppFeedbackDialog(
+                context,
+                title: AppStrings.feedbackErrorTitle,
+                message: failure.message,
+              ),
+            );
+          },
+        );
+      },
+      child: BlocBuilder<ProfileSubscriptionCubit, ProfileSubscriptionState>(
+        builder: (context, state) {
+          if (activeSubscription == null) {
+            return _ProfileSubscriptionEmptyState(
+              onPressed: _openCatalog,
+            );
+          }
+
+          return _ProfileSubscriptionActiveState(
+            activeSubscription: activeSubscription,
+            item: state.item,
+            isCardLoading: state.isLoading,
+            hasCardFailure: state.failure != null,
+            onRetryPressed: () => context.read<ProfileSubscriptionCubit>().retry(),
+            onRenewPressed: _openCatalog,
+            onCancelPressed: _showCancelDialog,
+          );
+        },
+      ),
+    );
+  }
+}
+
+final class _ProfileSubscriptionActiveState extends StatelessWidget {
+  final ProfileActiveSubscriptionSnapshot activeSubscription;
+  final SubscriptionCatalogItem? item;
+  final bool isCardLoading;
+  final bool hasCardFailure;
+  final VoidCallback onRetryPressed;
+  final VoidCallback onRenewPressed;
+  final VoidCallback onCancelPressed;
+
+  const _ProfileSubscriptionActiveState({
+    required this.activeSubscription,
+    required this.item,
+    required this.isCardLoading,
+    required this.hasCardFailure,
+    required this.onRetryPressed,
+    required this.onRenewPressed,
+    required this.onCancelPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorTheme = AppColorTheme.of(context);
+    final textTheme = AppTextTheme.of(context);
+    final resolvedPrice = item?.price ?? activeSubscription.price;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        RichText(
+          text: TextSpan(
+            style: textTheme.sectionTitle,
+            children: [
+              TextSpan(
+                text: '*',
+                style: textTheme.sectionTitle.copyWith(color: colorTheme.onSurface),
+              ),
+              TextSpan(
+                text: AppStrings.profileSubscriptionActiveTitleAccent,
+                style: textTheme.sectionTitle.copyWith(color: colorTheme.secondary),
+              ),
+              TextSpan(
+                text: AppStrings.profileSubscriptionActiveTitleSuffix,
+                style: textTheme.sectionTitle.copyWith(color: colorTheme.onSurface),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          _formatExpireDate(activeSubscription.endDate),
+          style: textTheme.bodyMedium.copyWith(color: colorTheme.onSurface),
+        ),
+        const SizedBox(height: 12),
+        if (item != null)
+          SubscriptionCard(
+            item: item!,
+            onPressed: () => context.push(AppRoutePaths.subscriptionsDetailsConcretePath(item!.id)),
+          )
+        else if (isCardLoading)
+          const _ProfileSubscriptionCardLoadingState()
+        else if (hasCardFailure)
+          _ProfileSubscriptionCardRetryState(onRetryPressed: onRetryPressed)
+        else
+          const _ProfileSubscriptionCardLoadingState(),
+        const SizedBox(height: 28),
+        Align(
+          alignment: Alignment.centerRight,
+          child: Text(
+            '${SubscriptionCard.formatPrice(resolvedPrice)} ${AppStrings.subscriptionsCatalogRubles}',
+            style: textTheme.bodyMedium.copyWith(
+              fontSize: 20,
+              height: 24 / 20,
+              fontWeight: FontWeight.w600,
+              color: colorTheme.onSurface,
+            ),
+          ),
+        ),
+        const SizedBox(height: 24),
+        MainButton(
+          onPressed: onRenewPressed,
+          child: const Text(AppStrings.profileSubscriptionRenewButton),
+        ),
+        const SizedBox(height: 12),
+        SecondaryButton(
+          onPressed: onCancelPressed,
+          child: const Text(AppStrings.profileSubscriptionCancelButton),
+        ),
+      ],
+    );
+  }
+}
+
+final class _ProfileSubscriptionCardLoadingState extends StatelessWidget {
+  const _ProfileSubscriptionCardLoadingState();
+
+  @override
+  Widget build(BuildContext context) {
+    final colorTheme = AppColorTheme.of(context);
+
+    return Container(
+      height: 306,
+      alignment: Alignment.center,
+      decoration: BoxDecoration(
+        color: colorTheme.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: colorTheme.secondary.withValues(alpha: 0.25),
+        ),
+      ),
+      child: const SizedBox.square(
+        dimension: 24,
+        child: CircularProgressIndicator.adaptive(strokeWidth: 2),
+      ),
+    );
+  }
+}
+
+final class _ProfileSubscriptionCardRetryState extends StatelessWidget {
+  final VoidCallback onRetryPressed;
+
+  const _ProfileSubscriptionCardRetryState({
+    required this.onRetryPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorTheme = AppColorTheme.of(context);
+    final textTheme = AppTextTheme.of(context);
+
+    return Container(
+      padding: const EdgeInsets.all(24),
+      decoration: BoxDecoration(
+        color: colorTheme.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: colorTheme.secondary.withValues(alpha: 0.25),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Text(
+            AppStrings.profileSubscriptionCardLoadFailed,
+            textAlign: TextAlign.center,
+            style: textTheme.bodyMedium.copyWith(color: colorTheme.onSurface),
+          ),
+          const SizedBox(height: 16),
+          MainButton(
+            onPressed: onRetryPressed,
+            child: const Text(AppStrings.profileSubscriptionCardRetryButton),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+final class _ProfileSubscriptionEmptyState extends StatelessWidget {
+  final VoidCallback onPressed;
+
+  const _ProfileSubscriptionEmptyState({
+    required this.onPressed,
+  });
+
+  static const _benefits = [
+    AppStrings.profileSubscriptionBenefitTrainings,
+    AppStrings.profileSubscriptionBenefitTestsAndExercises,
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    final colorTheme = AppColorTheme.of(context);
+    final textTheme = AppTextTheme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          AppStrings.profileSubscriptionEmptyTitle,
+          style: textTheme.sectionTitle.copyWith(color: colorTheme.onSurface),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          AppStrings.profileSubscriptionEmptySubtitle,
+          style: textTheme.bodyMedium.copyWith(color: colorTheme.onSurface),
+        ),
+        const SizedBox(height: 20),
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: List.generate(_benefits.length, (index) {
+            return Padding(
+              padding: EdgeInsets.only(bottom: index == _benefits.length - 1 ? 0 : 8),
+              child: _ProfileSubscriptionBenefitRow(text: _benefits[index]),
+            );
+          }),
+        ),
+        const SizedBox(height: 24),
+        MainButton(
+          onPressed: onPressed,
+          child: const Text(AppStrings.profileSubscriptionsButton),
+        ),
+      ],
+    );
+  }
+}
+
+final class _ProfileSubscriptionBenefitRow extends StatelessWidget {
+  final String text;
+
+  const _ProfileSubscriptionBenefitRow({
+    required this.text,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorTheme = AppColorTheme.of(context);
+    final textTheme = AppTextTheme.of(context);
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          width: 14,
+          height: 14,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: colorTheme.secondary.withValues(alpha: 0.5),
+          ),
+        ),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            text,
+            style: textTheme.body.copyWith(color: colorTheme.onSurface),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+String _formatExpireDate(String rawDate) {
+  final parsed = DateTime.tryParse(rawDate);
+  if (parsed == null) {
+    return '${AppStrings.profileSubscriptionExpiryPrefix} $rawDate';
+  }
+
+  const months = [
+    'января',
+    'февраля',
+    'марта',
+    'апреля',
+    'мая',
+    'июня',
+    'июля',
+    'августа',
+    'сентября',
+    'октября',
+    'ноября',
+    'декабря',
+  ];
+
+  return '${AppStrings.profileSubscriptionExpiryPrefix} '
+      '${parsed.day} ${months[parsed.month - 1]} ${parsed.year} г.';
+}

--- a/lib/features/subscriptions/data/remote/subscriptions_api_client.dart
+++ b/lib/features/subscriptions/data/remote/subscriptions_api_client.dart
@@ -20,4 +20,8 @@ abstract class SubscriptionsApiClient {
   /// Returns a single subscription by identifier.
   @GET('${ApiPaths.subscriptions}/{subscription}')
   Future<SubscriptionResponseDto> getSubscriptionById(@Path('subscription') int subscriptionId);
+
+  /// Cancels the currently active subscription.
+  @POST(ApiPaths.cancelSubscription)
+  Future<void> cancelSubscription();
 }

--- a/lib/features/subscriptions/data/repositories/subscriptions_repository_impl.dart
+++ b/lib/features/subscriptions/data/repositories/subscriptions_repository_impl.dart
@@ -96,6 +96,22 @@ final class SubscriptionsRepositoryImpl implements SubscriptionsRepository {
     }
   }
 
+  @override
+  Future<Result<void, SubscriptionsFailure>> cancelSubscription() async {
+    try {
+      await _apiClient.cancelSubscription();
+      return const Result.success(null);
+    } on DioException catch (e) {
+      final networkFailure = e.toNetworkFailure();
+      return Result.failure(networkFailure.toSubscriptionsFailure());
+    } catch (e, s) {
+      _logger.e('CancelSubscription failed with unexpected error', e, s);
+      return Result.failure(
+        UnknownSubscriptionsFailure(parentException: e, stackTrace: s),
+      );
+    }
+  }
+
   Future<List<SubscriptionCatalogItem>> _loadActiveSubscriptions() async {
     final response = await _apiClient.getSubscriptions();
     return response.data

--- a/lib/features/subscriptions/domain/repositories/subscriptions_repository.dart
+++ b/lib/features/subscriptions/domain/repositories/subscriptions_repository.dart
@@ -8,11 +8,14 @@ abstract interface class SubscriptionsRepository {
   /// Returns all subscriptions available for the catalog screen.
   Future<Result<List<SubscriptionCatalogItem>, SubscriptionsFailure>> getSubscriptions();
 
-  /// Returns a single subscription by [id] using the catalog source of truth.
+  /// Returns a single subscription by [id].
   Future<Result<SubscriptionCatalogItem, SubscriptionsFailure>> getSubscriptionById(int id);
 
   /// Pays for a subscription using the provided [payload].
   Future<Result<void, SubscriptionsFailure>> paySubscription({
     required SubscriptionPaymentPayload payload,
   });
+
+  /// Cancels the currently active subscription.
+  Future<Result<void, SubscriptionsFailure>> cancelSubscription();
 }

--- a/lib/features/subscriptions/presentation/cubits/cancel_subscription_cubit.dart
+++ b/lib/features/subscriptions/presentation/cubits/cancel_subscription_cubit.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../../../core/failures/feature/subscriptions/subscriptions_failure.dart';
+import '../../../../core/result/result.dart';
+import '../../domain/repositories/subscriptions_repository.dart';
+
+part 'cancel_subscription_cubit.freezed.dart';
+part 'cancel_subscription_state.dart';
+
+/// Cubit that manages the active subscription cancel flow.
+final class CancelSubscriptionCubit extends Cubit<CancelSubscriptionState> {
+  final SubscriptionsRepository _repository;
+
+  /// Creates an instance of [CancelSubscriptionCubit].
+  CancelSubscriptionCubit(this._repository) : super(const CancelSubscriptionState.initial());
+
+  /// Cancels the currently active subscription.
+  Future<void> cancelSubscription() async {
+    final isInProgress = state.maybeWhen(
+      inProgress: () => true,
+      orElse: () => false,
+    );
+    if (isInProgress) return;
+
+    emit(const CancelSubscriptionState.inProgress());
+
+    final result = await _repository.cancelSubscription();
+    if (isClosed) return;
+
+    switch (result) {
+      case Success():
+        emit(const CancelSubscriptionState.succeed());
+      case Failure(:final error):
+        emit(CancelSubscriptionState.failed(error));
+    }
+  }
+}

--- a/lib/features/subscriptions/presentation/cubits/cancel_subscription_state.dart
+++ b/lib/features/subscriptions/presentation/cubits/cancel_subscription_state.dart
@@ -1,0 +1,17 @@
+part of 'cancel_subscription_cubit.dart';
+
+/// State for [CancelSubscriptionCubit].
+@freezed
+sealed class CancelSubscriptionState with _$CancelSubscriptionState {
+  /// Initial idle state.
+  const factory CancelSubscriptionState.initial() = _Initial;
+
+  /// Cancel request is in progress.
+  const factory CancelSubscriptionState.inProgress() = _InProgress;
+
+  /// Cancel request completed successfully.
+  const factory CancelSubscriptionState.succeed() = _Succeed;
+
+  /// Cancel request failed.
+  const factory CancelSubscriptionState.failed(SubscriptionsFailure failure) = _Failed;
+}

--- a/lib/features/subscriptions/presentation/pages/subscriptions_details_page.dart
+++ b/lib/features/subscriptions/presentation/pages/subscriptions_details_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';

--- a/lib/features/subscriptions/presentation/pages/subscriptions_details_page.dart
+++ b/lib/features/subscriptions/presentation/pages/subscriptions_details_page.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 
 import '../../../../core/constants/app_assets.dart';
 import '../../../../core/constants/app_strings.dart';
+import '../../../../core/di/di.dart';
 import '../../../../core/router/router_paths.dart';
 import '../../../../uikit/buttons/app_back_button.dart';
 import '../../../../uikit/buttons/main_button.dart';
@@ -13,6 +14,7 @@ import '../../../../uikit/cards/app_card.dart';
 import '../../../../uikit/images/svg_picture_widget.dart';
 import '../../../../uikit/themes/colors/app_color_theme.dart';
 import '../../../../uikit/themes/text/app_text_theme.dart';
+import '../../../profile/presentation/cubits/profile_refresh_cubit.dart';
 import '../../domain/entities/subscription_catalog_item.dart';
 import '../cubits/subscription_details_cubit.dart';
 import '../cubits/subscription_payment_cubit.dart';
@@ -48,6 +50,7 @@ class SubscriptionsDetailsPage extends StatelessWidget {
       paymentCubit: context.read<SubscriptionPaymentCubit>(),
     );
     if (!context.mounted || didPay != true) return;
+    di<ProfileRefreshCubit>().requestRefresh();
     context.go(AppRoutePaths.profilePath);
   }
 

--- a/lib/features/subscriptions/presentation/pages/subscriptions_details_page_builder.dart
+++ b/lib/features/subscriptions/presentation/pages/subscriptions_details_page_builder.dart
@@ -2,8 +2,6 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../../../core/di/di.dart';
-import '../../../profile/domain/repositories/profile_repository.dart';
-import '../../../profile/presentation/cubits/profile_user_cubit.dart';
 import '../../domain/entities/subscription_catalog_item.dart';
 import '../../domain/repositories/subscriptions_repository.dart';
 import '../cubits/subscription_details_cubit.dart';
@@ -29,9 +27,6 @@ class SubscriptionsDetailsPageBuilder extends StatelessWidget {
   Widget build(BuildContext context) {
     return MultiBlocProvider(
       providers: [
-        BlocProvider(
-          create: (_) => ProfileUserCubit(di<ProfileRepository>()),
-        ),
         BlocProvider(
           create: (_) => SubscriptionDetailsCubit(
             di<SubscriptionsRepository>(),

--- a/lib/features/subscriptions/presentation/pages/subscriptions_details_page_builder.dart
+++ b/lib/features/subscriptions/presentation/pages/subscriptions_details_page_builder.dart
@@ -2,6 +2,8 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../../../core/di/di.dart';
+import '../../../profile/domain/repositories/profile_repository.dart';
+import '../../../profile/presentation/cubits/profile_user_cubit.dart';
 import '../../domain/entities/subscription_catalog_item.dart';
 import '../../domain/repositories/subscriptions_repository.dart';
 import '../cubits/subscription_details_cubit.dart';
@@ -27,6 +29,9 @@ class SubscriptionsDetailsPageBuilder extends StatelessWidget {
   Widget build(BuildContext context) {
     return MultiBlocProvider(
       providers: [
+        BlocProvider(
+          create: (_) => ProfileUserCubit(di<ProfileRepository>()),
+        ),
         BlocProvider(
           create: (_) => SubscriptionDetailsCubit(
             di<SubscriptionsRepository>(),

--- a/lib/uikit/themes/text/app_text_style.dart
+++ b/lib/uikit/themes/text/app_text_style.dart
@@ -26,6 +26,13 @@ abstract class AppTextStyle {
     fontWeight: FontWeight.w600,
   );
 
+  static const sectionTitle = TextStyle(
+    fontFamily: _fontFamily,
+    fontSize: 18,
+    height: 27 / 18,
+    fontWeight: FontWeight.w600,
+  );
+
   static const body = TextStyle(
     fontFamily: _fontFamily,
     fontSize: 12,

--- a/lib/uikit/themes/text/app_text_theme.dart
+++ b/lib/uikit/themes/text/app_text_theme.dart
@@ -13,6 +13,7 @@ class AppTextTheme extends ThemeExtension<AppTextTheme> {
   final TextStyle display;
   final TextStyle title;
   final TextStyle appBarTitle;
+  final TextStyle sectionTitle;
   final TextStyle body;
   final TextStyle bodyMedium;
   final TextStyle bodySmall;
@@ -23,6 +24,7 @@ class AppTextTheme extends ThemeExtension<AppTextTheme> {
     required this.display,
     required this.title,
     required this.appBarTitle,
+    required this.sectionTitle,
     required this.body,
     required this.bodyMedium,
     required this.bodySmall,
@@ -34,6 +36,7 @@ class AppTextTheme extends ThemeExtension<AppTextTheme> {
     : display = AppTextStyle.display,
       title = AppTextStyle.title,
       appBarTitle = AppTextStyle.appBarTitle,
+      sectionTitle = AppTextStyle.sectionTitle,
       body = AppTextStyle.body,
       bodyMedium = AppTextStyle.bodyMedium,
       bodySmall = AppTextStyle.bodySmall,
@@ -45,6 +48,7 @@ class AppTextTheme extends ThemeExtension<AppTextTheme> {
     TextStyle? display,
     TextStyle? title,
     TextStyle? appBarTitle,
+    TextStyle? sectionTitle,
     TextStyle? body,
     TextStyle? bodyMedium,
     TextStyle? bodySmall,
@@ -55,6 +59,7 @@ class AppTextTheme extends ThemeExtension<AppTextTheme> {
       display: display ?? this.display,
       title: title ?? this.title,
       appBarTitle: appBarTitle ?? this.appBarTitle,
+      sectionTitle: sectionTitle ?? this.sectionTitle,
       body: body ?? this.body,
       bodyMedium: bodyMedium ?? this.bodyMedium,
       bodySmall: bodySmall ?? this.bodySmall,
@@ -72,6 +77,7 @@ class AppTextTheme extends ThemeExtension<AppTextTheme> {
       display: TextStyle.lerp(display, other.display, t)!,
       title: TextStyle.lerp(title, other.title, t)!,
       appBarTitle: TextStyle.lerp(appBarTitle, other.appBarTitle, t)!,
+      sectionTitle: TextStyle.lerp(sectionTitle, other.sectionTitle, t)!,
       body: TextStyle.lerp(body, other.body, t)!,
       bodyMedium: TextStyle.lerp(bodyMedium, other.bodyMedium, t)!,
       bodySmall: TextStyle.lerp(bodySmall, other.bodySmall, t)!,

--- a/test/features/profile/presentation/cubits/profile_subscription_cubit_test.dart
+++ b/test/features/profile/presentation/cubits/profile_subscription_cubit_test.dart
@@ -1,0 +1,157 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:moveup_flutter/core/failures/feature/subscriptions/subscriptions_failure.dart';
+import 'package:moveup_flutter/core/result/result.dart';
+import 'package:moveup_flutter/features/profile/domain/entities/profile_stats_history_snapshot.dart';
+import 'package:moveup_flutter/features/profile/presentation/cubits/profile_subscription_cubit.dart';
+import 'package:moveup_flutter/features/subscriptions/domain/entities/subscription_catalog_item.dart';
+import 'package:moveup_flutter/features/subscriptions/domain/repositories/subscriptions_repository.dart';
+
+import '../../support/profile_dto_fixtures.dart';
+import '../../../subscriptions/support/subscriptions_dto_fixtures.dart';
+import 'profile_subscription_cubit_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<SubscriptionsRepository>()])
+void main() {
+  late MockSubscriptionsRepository repository;
+  late ProfileSubscriptionCubit cubit;
+
+  const activeSubscription = ProfileActiveSubscriptionSnapshot(
+    id: testProfileSubscriptionId,
+    name: testProfileSubscriptionName,
+    price: testProfileSubscriptionPrice,
+    startDate: testProfileSubscriptionStartDate,
+    endDate: testProfileSubscriptionEndDate,
+  );
+  final item = createSubscriptionCatalogItems().last;
+
+  setUp(() {
+    repository = MockSubscriptionsRepository();
+    cubit = ProfileSubscriptionCubit(repository);
+    provideDummy<Result<SubscriptionCatalogItem, SubscriptionsFailure>>(
+      Success<SubscriptionCatalogItem, SubscriptionsFailure>(item),
+    );
+    provideDummy<Result<List<SubscriptionCatalogItem>, SubscriptionsFailure>>(
+      Success<List<SubscriptionCatalogItem>, SubscriptionsFailure>(
+        createSubscriptionCatalogItems(),
+      ),
+    );
+  });
+
+  group('ProfileSubscriptionCubit', () {
+    blocTest<ProfileSubscriptionCubit, ProfileSubscriptionState>(
+      'emits empty state when active subscription is absent',
+      build: () => cubit,
+      seed: () => ProfileSubscriptionState(
+        activeSubscription: activeSubscription,
+        item: item,
+        failure: const SubscriptionsRequestFailure('test'),
+      ),
+      act: (cubit) => cubit.syncActiveSubscription(null),
+      expect: () => const [
+        ProfileSubscriptionState(),
+      ],
+      verify: (_) => verifyNever(repository.getSubscriptionById(any)),
+    );
+
+    blocTest<ProfileSubscriptionCubit, ProfileSubscriptionState>(
+      'loads details when active subscription appears',
+      setUp: () => when(repository.getSubscriptions()).thenAnswer(
+        (_) async => Success<List<SubscriptionCatalogItem>, SubscriptionsFailure>(
+          createSubscriptionCatalogItems(),
+        ),
+      ),
+      build: () => cubit,
+      act: (cubit) => cubit.syncActiveSubscription(activeSubscription),
+      expect: () => [
+        const ProfileSubscriptionState(
+          isLoading: true,
+          activeSubscription: activeSubscription,
+        ),
+        ProfileSubscriptionState(
+          activeSubscription: activeSubscription,
+          item: item,
+        ),
+      ],
+      verify: (_) => verify(repository.getSubscriptions()).called(1),
+    );
+
+    blocTest<ProfileSubscriptionCubit, ProfileSubscriptionState>(
+      'ignores duplicate sync with same subscriptionId',
+      build: () => cubit,
+      seed: () => ProfileSubscriptionState(
+        activeSubscription: activeSubscription,
+        item: item,
+      ),
+      act: (cubit) => cubit.syncActiveSubscription(activeSubscription),
+      expect: () => const <ProfileSubscriptionState>[],
+      verify: (_) => verifyNever(repository.getSubscriptions()),
+    );
+
+    blocTest<ProfileSubscriptionCubit, ProfileSubscriptionState>(
+      'emits failed retry state when details request fails',
+      setUp: () => when(repository.getSubscriptions()).thenAnswer(
+        (_) async => const Failure<List<SubscriptionCatalogItem>, SubscriptionsFailure>(
+          SubscriptionsRequestFailure('error_message'),
+        ),
+      ),
+      build: () => cubit,
+      act: (cubit) => cubit.syncActiveSubscription(activeSubscription),
+      expect: () => const [
+        ProfileSubscriptionState(
+          isLoading: true,
+          activeSubscription: activeSubscription,
+        ),
+        ProfileSubscriptionState(
+          activeSubscription: activeSubscription,
+          failure: SubscriptionsRequestFailure('error_message'),
+        ),
+      ],
+      verify: (_) => verify(repository.getSubscriptions()).called(1),
+    );
+
+    blocTest<ProfileSubscriptionCubit, ProfileSubscriptionState>(
+      'matches active subscription to catalog item by name and price instead of active id',
+      setUp: () => when(repository.getSubscriptions()).thenAnswer(
+        (_) async => Success<List<SubscriptionCatalogItem>, SubscriptionsFailure>(
+          createSubscriptionCatalogItems(),
+        ),
+      ),
+      build: () => cubit,
+      act: (cubit) => cubit.syncActiveSubscription(
+        const ProfileActiveSubscriptionSnapshot(
+          id: 90,
+          name: '3 месяца',
+          price: '1400.00',
+          startDate: testProfileSubscriptionStartDate,
+          endDate: testProfileSubscriptionEndDate,
+        ),
+      ),
+      expect: () => [
+        const ProfileSubscriptionState(
+          isLoading: true,
+          activeSubscription: ProfileActiveSubscriptionSnapshot(
+            id: 90,
+            name: '3 месяца',
+            price: '1400.00',
+            startDate: testProfileSubscriptionStartDate,
+            endDate: testProfileSubscriptionEndDate,
+          ),
+        ),
+        ProfileSubscriptionState(
+          activeSubscription: const ProfileActiveSubscriptionSnapshot(
+            id: 90,
+            name: '3 месяца',
+            price: '1400.00',
+            startDate: testProfileSubscriptionStartDate,
+            endDate: testProfileSubscriptionEndDate,
+          ),
+          item: item,
+        ),
+      ],
+      verify: (_) => verify(repository.getSubscriptions()).called(1),
+    );
+  });
+}

--- a/test/features/profile/presentation/cubits/profile_subscription_cubit_test.dart
+++ b/test/features/profile/presentation/cubits/profile_subscription_cubit_test.dart
@@ -9,8 +9,8 @@ import 'package:moveup_flutter/features/profile/presentation/cubits/profile_subs
 import 'package:moveup_flutter/features/subscriptions/domain/entities/subscription_catalog_item.dart';
 import 'package:moveup_flutter/features/subscriptions/domain/repositories/subscriptions_repository.dart';
 
-import '../../support/profile_dto_fixtures.dart';
 import '../../../subscriptions/support/subscriptions_dto_fixtures.dart';
+import '../../support/profile_dto_fixtures.dart';
 import 'profile_subscription_cubit_test.mocks.dart';
 
 @GenerateNiceMocks([MockSpec<SubscriptionsRepository>()])
@@ -53,7 +53,7 @@ void main() {
       expect: () => const [
         ProfileSubscriptionState(),
       ],
-      verify: (_) => verifyNever(repository.getSubscriptionById(any)),
+      verify: (_) => verifyNever(repository.getSubscriptions()),
     );
 
     blocTest<ProfileSubscriptionCubit, ProfileSubscriptionState>(

--- a/test/features/subscriptions/data/repositories/subscriptions_repository_impl_test.dart
+++ b/test/features/subscriptions/data/repositories/subscriptions_repository_impl_test.dart
@@ -247,5 +247,51 @@ void main() {
         },
       );
     });
+
+    group('SubscriptionsRepositoryImpl.cancelSubscription', () {
+      test('returns success when cancel api succeeds', () async {
+        when(apiClient.cancelSubscription()).thenAnswer((_) async {});
+
+        final result = await repository.cancelSubscription();
+
+        expect(result.isSuccess, isTrue);
+        verify(apiClient.cancelSubscription()).called(1);
+        verifyNever(logger.e(any, any, any));
+        verifyNoMoreInteractions(apiClient);
+      });
+
+      test('returns SubscriptionsRequestFailure when cancel api returns server error', () async {
+        final exception = createSubscriptionsDioBadResponseException(
+          path: '/cancel-subscription',
+          statusCode: 500,
+        );
+        when(apiClient.cancelSubscription()).thenThrow(exception);
+
+        final result = await repository.cancelSubscription();
+
+        expect(result.isFailure, isTrue);
+        expect(result.failure, isA<SubscriptionsRequestFailure>());
+        expect(result.failure!.parentException, exception);
+
+        verify(apiClient.cancelSubscription()).called(1);
+        verifyNever(logger.e(any, any, any));
+        verifyNoMoreInteractions(apiClient);
+      });
+
+      test('returns UnknownSubscriptionsFailure when cancel throws unexpected exception', () async {
+        final exception = Exception('unexpected_cancel_error');
+        when(apiClient.cancelSubscription()).thenThrow(exception);
+
+        final result = await repository.cancelSubscription();
+
+        expect(result.isFailure, isTrue);
+        expect(result.failure, isA<UnknownSubscriptionsFailure>());
+        expect(result.failure!.parentException, exception);
+
+        verify(apiClient.cancelSubscription()).called(1);
+        verify(logger.e(any, exception, any)).called(1);
+        verifyNoMoreInteractions(apiClient);
+      });
+    });
   });
 }

--- a/test/features/subscriptions/presentation/cubits/cancel_subscription_cubit_test.dart
+++ b/test/features/subscriptions/presentation/cubits/cancel_subscription_cubit_test.dart
@@ -1,0 +1,69 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:moveup_flutter/core/failures/feature/subscriptions/subscriptions_failure.dart';
+import 'package:moveup_flutter/core/result/result.dart';
+import 'package:moveup_flutter/features/subscriptions/domain/repositories/subscriptions_repository.dart';
+import 'package:moveup_flutter/features/subscriptions/presentation/cubits/cancel_subscription_cubit.dart';
+
+import 'cancel_subscription_cubit_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<SubscriptionsRepository>()])
+void main() {
+  late MockSubscriptionsRepository repository;
+  late CancelSubscriptionCubit cubit;
+
+  const failure = SubscriptionsRequestFailure('test');
+
+  setUp(() {
+    repository = MockSubscriptionsRepository();
+    cubit = CancelSubscriptionCubit(repository);
+    provideDummy<Result<void, SubscriptionsFailure>>(const Success(null));
+  });
+
+  group('CancelSubscriptionCubit', () {
+    blocTest<CancelSubscriptionCubit, CancelSubscriptionState>(
+      'emits inProgress and succeed when cancel succeeds',
+      setUp: () =>
+          when(repository.cancelSubscription()).thenAnswer((_) async => const Success(null)),
+      build: () => cubit,
+      act: (cubit) => cubit.cancelSubscription(),
+      expect: () => const [
+        CancelSubscriptionState.inProgress(),
+        CancelSubscriptionState.succeed(),
+      ],
+      verify: (_) => verify(repository.cancelSubscription()).called(1),
+    );
+
+    blocTest<CancelSubscriptionCubit, CancelSubscriptionState>(
+      'emits failed(failure) when cancel fails',
+      setUp: () => when(
+        repository.cancelSubscription(),
+      ).thenAnswer((_) async => const Failure(failure)),
+      build: () => cubit,
+      act: (cubit) => cubit.cancelSubscription(),
+      expect: () => const [
+        CancelSubscriptionState.inProgress(),
+        CancelSubscriptionState.failed(failure),
+      ],
+      verify: (_) => verify(repository.cancelSubscription()).called(1),
+    );
+
+    blocTest<CancelSubscriptionCubit, CancelSubscriptionState>(
+      'emits inProgress only once when cancelSubscription is called twice',
+      setUp: () =>
+          when(repository.cancelSubscription()).thenAnswer((_) async => const Success(null)),
+      build: () => cubit,
+      act: (cubit) {
+        cubit.cancelSubscription();
+        cubit.cancelSubscription();
+      },
+      expect: () => const [
+        CancelSubscriptionState.inProgress(),
+        CancelSubscriptionState.succeed(),
+      ],
+      verify: (_) => verify(repository.cancelSubscription()).called(1),
+    );
+  });
+}


### PR DESCRIPTION
## 🚀 Summary

Implemented the full profile subscription section vertical slice for the authenticated `/profile` tab end-to-end (API contract → repository → cubit → UI → history modal).

## 🧪 Verification

- [x] `flutter analyze`
- [x] `flutter test test/features/subscriptions`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Profile subscription section displaying active subscription status, expiry date, and subscription benefits
  * Implemented subscription cancellation with confirmation dialog and profile auto-refresh after action
  * Added empty state messaging when no active subscription exists

* **Documentation**
  * Updated changelog describing new profile subscription section features

* **Tests**
  * Added unit tests for subscription profile management and cancellation workflows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->