### PR TITLE
 feat(profile): implement profile cards section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduce personal parameters section for the authenticated `/profile` tab, including canonical `user-parameters` read/update flow, editable profile form card, weekly-goal save support, and selective workouts overview refresh when goal, equipment, or level changes regenerate the personal plan.
 - Add profile bottom section for the authenticated `/profile` tab, including logout and delete-profile confirmation actions plus direct links to the bundled legal documents.
 - Profile subscription section for the authenticated `/profile` tab, including active and empty subscription states, catalog entrypoints, profile-local subscription card hydration by `subscriptionId`, cancel-subscription confirmation flow and profile page refresh after cancellation.
+- Profile saved cards section for the authenticated `/profile` tab, including dedicated cards API/repository flow, saved-cards list rendering, add-card dialog with manual card form, default-card command, delete-card confirmation, and local refresh after successful actions.
 - Authenticated subscriptions catalog screen, including dedicated subscriptions route, catalog Cubit, card UI with normalized remote images, and a profile CTA for opening available subscription plans.
 - Authenticated subscription details and payment flow, including a dedicated details route, catalog-backed item resolution, manual-card payment dialog, and redirect to `/profile` after successful purchase.
 

--- a/assets/icons/card_small.svg
+++ b/assets/icons/card_small.svg
@@ -1,0 +1,12 @@
+<svg width="107" height="69" viewBox="0 0 107 69" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_7070_4899)">
+<rect width="107" height="69" rx="8" fill="#89C8C8"/>
+<ellipse cx="107.464" cy="-3.13482" rx="57" ry="48" transform="rotate(-137.693 107.464 -3.13482)" fill="#3BA3A4"/>
+<ellipse cx="-4.53613" cy="73.8652" rx="57" ry="48" transform="rotate(-137.693 -4.53613 73.8652)" fill="#3BA3A4"/>
+</g>
+<defs>
+<clipPath id="clip0_7070_4899">
+<rect width="107" height="69" rx="8" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/assets/icons/close_variant.svg
+++ b/assets/icons/close_variant.svg
@@ -1,0 +1,4 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4.99974 14.2109L13.7413 4.307" stroke="#2A2A2A" stroke-width="1.5" stroke-linecap="round"/>
+<path d="M13.7351 14.2155L5.00821 4.29864" stroke="#2A2A2A" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/assets/icons/plus.svg
+++ b/assets/icons/plus.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 3V21" stroke="#2A2A2A" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3 12H21" stroke="#2A2A2A" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/lib/core/constants/app_assets.dart
+++ b/lib/core/constants/app_assets.dart
@@ -21,6 +21,8 @@ abstract final class AppAssets {
   static const iconArrowDown = 'arrow_down';
   static const iconStats = 'stats';
   static const iconCardBig = 'card_big';
+  static const iconCardSmall = 'card_small';
+  static const iconPlus = 'plus';
 
   // Images.
   static const imageFigure = 'figure';

--- a/lib/core/constants/app_assets.dart
+++ b/lib/core/constants/app_assets.dart
@@ -14,6 +14,7 @@ abstract final class AppAssets {
   static const iconSearch = 'search';
   static const iconFilter = 'filter';
   static const iconClose = 'close';
+  static const iconCloseVariant = 'close_variant';
   static const iconNotification = 'notification';
   static const iconBadFace = 'bad_face';
   static const iconNormalFace = 'normal_face';

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -208,6 +208,10 @@ abstract final class AppStrings {
       'У вас уже есть начатая тренировка. Сначала завершите её, чтобы начать новую';
   static const workoutsUnknown = 'Не удалось выполнить действие. Попробуйте снова';
 
+  // Cards.
+  static const cardsValidationFailed = 'Проверьте введенные данные и попробуйте снова';
+  static const cardsUnknown = 'Не удалось выполнить действие. Попробуйте снова';
+
   // Subscriptions catalog.
   static const subscriptionsCatalogTitle = 'Подписки';
   static const subscriptionsCatalogEmpty = 'Подписки не найдены';

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -216,7 +216,7 @@ abstract final class AppStrings {
   static const cardsAddButton = 'Добавить карту';
   static const cardsDefaultButton = 'Основная карта';
   static const cardsMakeDefaultButton = 'Сделать карту основной';
-  static const cardsDeleteTitle = 'Удалить карту?';
+  static const cardsDeleteTitle = 'Удалить карту';
   static const cardsDeleteDescription = 'Вы действительно хотите удалить карту?';
   static const cardsDeleteConfirmButton = 'Подтвердить';
   static const cardsAddLimitTitle = 'Нельзя добавить карту';

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -211,6 +211,16 @@ abstract final class AppStrings {
   // Cards.
   static const cardsValidationFailed = 'Проверьте введенные данные и попробуйте снова';
   static const cardsUnknown = 'Не удалось выполнить действие. Попробуйте снова';
+  static const cardsSectionTitle = 'Мои карты';
+  static const cardsLoadFailed = 'Не удалось загрузить карты';
+  static const cardsAddButton = 'Добавить карту';
+  static const cardsDefaultButton = 'Основная карта';
+  static const cardsMakeDefaultButton = 'Сделать карту основной';
+  static const cardsDeleteTitle = 'Удалить карту?';
+  static const cardsDeleteDescription = 'Вы действительно хотите удалить карту?';
+  static const cardsDeleteConfirmButton = 'Подтвердить';
+  static const cardsAddLimitTitle = 'Нельзя добавить карту';
+  static const cardsAddLimitMessage = 'Можно сохранить не более 3 карт';
 
   // Subscriptions catalog.
   static const subscriptionsCatalogTitle = 'Подписки';

--- a/lib/core/di/di.dart
+++ b/lib/core/di/di.dart
@@ -13,6 +13,9 @@ import '../../features/auth/data/remote/auth_api_client.dart';
 import '../../features/auth/data/repositories/auth_repository_impl.dart';
 import '../../features/auth/domain/repositories/auth_repository.dart';
 import '../../features/auth/presentation/cubits/auth_session_cubit.dart';
+import '../../features/cards/data/remote/cards_api_client.dart';
+import '../../features/cards/data/repositories/cards_repository_impl.dart';
+import '../../features/cards/domain/repositories/cards_repository.dart';
 import '../../features/fitness_start/data/remote/fitness_start_api_client.dart';
 import '../../features/fitness_start/data/repositories/fitness_start_repository_impl.dart';
 import '../../features/fitness_start/domain/repositories/fitness_start_repository.dart';
@@ -157,8 +160,15 @@ Future<void> setupDI() async {
     ),
   );
   di.registerLazySingleton<SubscriptionsApiClient>(() => SubscriptionsApiClient(di<Dio>()));
+  di.registerLazySingleton<CardsApiClient>(() => CardsApiClient(di<Dio>()));
   di.registerLazySingleton<SubscriptionPaymentApiClient>(
     () => SubscriptionPaymentApiClient(di<Dio>()),
+  );
+  di.registerLazySingleton<CardsRepository>(
+    () => CardsRepositoryImpl(
+      di<AppLogger>(),
+      di<CardsApiClient>(),
+    ),
   );
   di.registerLazySingleton<SubscriptionsRepository>(
     () => SubscriptionsRepositoryImpl(

--- a/lib/core/failures/feature/cards/cards_failure.dart
+++ b/lib/core/failures/feature/cards/cards_failure.dart
@@ -1,0 +1,41 @@
+import '../../../constants/app_strings.dart';
+import '../../app_failure.dart';
+
+/// Cards application error.
+sealed class CardsFailure extends AppFailure {
+  /// Creates an instance of [CardsFailure].
+  const CardsFailure(
+    super.message, {
+    super.parentException,
+    super.stackTrace,
+  });
+}
+
+/// Cards validation failed because the provided input is invalid.
+final class CardsValidationFailure extends CardsFailure {
+  /// Creates an instance of [CardsValidationFailure].
+  const CardsValidationFailure({
+    String message = AppStrings.cardsValidationFailed,
+    super.parentException,
+    super.stackTrace,
+  }) : super(message);
+}
+
+/// Cards request failed because of infrastructure or network conditions.
+final class CardsRequestFailure extends CardsFailure {
+  /// Creates an instance of [CardsRequestFailure].
+  const CardsRequestFailure(
+    super.message, {
+    super.parentException,
+    super.stackTrace,
+  });
+}
+
+/// Unknown cards failure.
+final class UnknownCardsFailure extends CardsFailure {
+  /// Creates an instance of [UnknownCardsFailure].
+  const UnknownCardsFailure({
+    super.parentException,
+    super.stackTrace,
+  }) : super(AppStrings.cardsUnknown);
+}

--- a/lib/core/network/api_paths.dart
+++ b/lib/core/network/api_paths.dart
@@ -113,6 +113,15 @@ abstract class ApiPaths {
   /// The endpoint for paying for a subscription.
   static const String paymentSubscription = '${apiPrefix}payment/subscription';
 
+  /// The endpoint for saved cards list.
+  static const String paymentCards = '${apiPrefix}payment/cards';
+
+  /// The endpoint for saving a new card.
+  static const String paymentCardsSave = '$paymentCards/save';
+
+  /// The endpoint prefix for card default command.
+  static const String paymentCardsDefault = '$paymentCards/{cardId}/default';
+
   /// The endpoint for starting a workout.
   static const String workoutsStart = '$workouts/start';
 

--- a/lib/features/cards/data/dto/save_card_request_dto.dart
+++ b/lib/features/cards/data/dto/save_card_request_dto.dart
@@ -1,0 +1,34 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'save_card_request_dto.g.dart';
+
+/// DTO for saving a new payment card.
+@JsonSerializable(createFactory: false)
+class SaveCardRequestDto {
+  /// Manual card number.
+  @JsonKey(name: 'card_number')
+  final String cardNumber;
+
+  /// Manual card holder name.
+  @JsonKey(name: 'card_holder')
+  final String cardHolder;
+
+  /// Card expiry month.
+  @JsonKey(name: 'expiry_month')
+  final String expiryMonth;
+
+  /// Card expiry year.
+  @JsonKey(name: 'expiry_year')
+  final String expiryYear;
+
+  /// Creates an instance of [SaveCardRequestDto].
+  SaveCardRequestDto({
+    required this.cardNumber,
+    required this.cardHolder,
+    required this.expiryMonth,
+    required this.expiryYear,
+  });
+
+  /// Converts [SaveCardRequestDto] to JSON.
+  Map<String, dynamic> toJson() => _$SaveCardRequestDtoToJson(this);
+}

--- a/lib/features/cards/data/dto/saved_card_dto.dart
+++ b/lib/features/cards/data/dto/saved_card_dto.dart
@@ -1,0 +1,43 @@
+import 'package:json_annotation/json_annotation.dart';
+
+part 'saved_card_dto.g.dart';
+
+/// DTO for a saved payment card.
+@JsonSerializable(createToJson: false)
+class SavedCardDto {
+  /// Card identifier.
+  final int id;
+
+  /// Card holder name.
+  @JsonKey(name: 'card_holder')
+  final String cardHolder;
+
+  /// Last four digits of the card number.
+  @JsonKey(name: 'card_last_four')
+  final String cardLastFour;
+
+  /// Expiry month.
+  @JsonKey(name: 'expiry_month')
+  final String expiryMonth;
+
+  /// Expiry year.
+  @JsonKey(name: 'expiry_year')
+  final String expiryYear;
+
+  /// Whether the card is default.
+  @JsonKey(name: 'is_default')
+  final bool isDefault;
+
+  /// Creates an instance of [SavedCardDto].
+  SavedCardDto({
+    required this.id,
+    required this.cardHolder,
+    required this.cardLastFour,
+    required this.expiryMonth,
+    required this.expiryYear,
+    required this.isDefault,
+  });
+
+  /// Creates a [SavedCardDto] from JSON.
+  factory SavedCardDto.fromJson(Map<String, dynamic> json) => _$SavedCardDtoFromJson(json);
+}

--- a/lib/features/cards/data/dto/saved_cards_response_dto.dart
+++ b/lib/features/cards/data/dto/saved_cards_response_dto.dart
@@ -1,0 +1,19 @@
+import 'package:json_annotation/json_annotation.dart';
+
+import 'saved_card_dto.dart';
+
+part 'saved_cards_response_dto.g.dart';
+
+/// DTO for saved cards response envelope.
+@JsonSerializable(createToJson: false)
+class SavedCardsResponseDto {
+  /// Cards payload.
+  final List<SavedCardDto> data;
+
+  /// Creates an instance of [SavedCardsResponseDto].
+  SavedCardsResponseDto({required this.data});
+
+  /// Creates a [SavedCardsResponseDto] from JSON.
+  factory SavedCardsResponseDto.fromJson(Map<String, dynamic> json) =>
+      _$SavedCardsResponseDtoFromJson(json);
+}

--- a/lib/features/cards/data/mappers/cards_failure_mapper.dart
+++ b/lib/features/cards/data/mappers/cards_failure_mapper.dart
@@ -1,0 +1,48 @@
+import '../../../../core/failures/feature/cards/cards_failure.dart';
+import '../../../../core/failures/helpers/validation_message_builder.dart';
+import '../../../../core/failures/network/network_failure.dart';
+
+/// Extension to map [NetworkFailure] into [CardsFailure].
+extension CardsFailureMapper on NetworkFailure {
+  /// Maps a [NetworkFailure] into a cards-specific failure.
+  CardsFailure toCardsFailure() {
+    final fieldErrors = switch (this) {
+      ValidationFailure(:final errors) => errors,
+      _ => const <String, List<String>>{},
+    };
+    final validationMessage = buildValidationMessage(
+      fieldErrors,
+      fallbackMessage: const CardsValidationFailure().message,
+    );
+
+    switch (code) {
+      case 'validation_failed':
+        return CardsValidationFailure(
+          message: validationMessage,
+          parentException: parentException,
+          stackTrace: stackTrace,
+        );
+      default:
+        return switch (this) {
+          NoNetworkFailure() ||
+          ConnectionTimeoutFailure() ||
+          BadRequestFailure() ||
+          UnauthorizedFailure() ||
+          ForbiddenFailure() ||
+          NotFoundFailure() ||
+          ConflictFailure() ||
+          RateLimitedFailure() ||
+          ServerErrorFailure() ||
+          UnknownNetworkFailure() => CardsRequestFailure(
+            message,
+            parentException: parentException,
+            stackTrace: stackTrace,
+          ),
+          _ => UnknownCardsFailure(
+            parentException: parentException,
+            stackTrace: stackTrace,
+          ),
+        };
+    }
+  }
+}

--- a/lib/features/cards/data/mappers/cards_failure_mapper.dart
+++ b/lib/features/cards/data/mappers/cards_failure_mapper.dart
@@ -6,43 +6,40 @@ import '../../../../core/failures/network/network_failure.dart';
 extension CardsFailureMapper on NetworkFailure {
   /// Maps a [NetworkFailure] into a cards-specific failure.
   CardsFailure toCardsFailure() {
-    final fieldErrors = switch (this) {
-      ValidationFailure(:final errors) => errors,
-      _ => const <String, List<String>>{},
-    };
-    final validationMessage = buildValidationMessage(
-      fieldErrors,
-      fallbackMessage: const CardsValidationFailure().message,
-    );
-
-    switch (code) {
-      case 'validation_failed':
-        return CardsValidationFailure(
-          message: validationMessage,
-          parentException: parentException,
-          stackTrace: stackTrace,
-        );
-      default:
-        return switch (this) {
-          NoNetworkFailure() ||
-          ConnectionTimeoutFailure() ||
-          BadRequestFailure() ||
-          UnauthorizedFailure() ||
-          ForbiddenFailure() ||
-          NotFoundFailure() ||
-          ConflictFailure() ||
-          RateLimitedFailure() ||
-          ServerErrorFailure() ||
-          UnknownNetworkFailure() => CardsRequestFailure(
-            message,
-            parentException: parentException,
-            stackTrace: stackTrace,
-          ),
-          _ => UnknownCardsFailure(
-            parentException: parentException,
-            stackTrace: stackTrace,
-          ),
-        };
+    if (this case ValidationFailure(:final errors)) {
+      final validationMessage = buildValidationMessage(
+        errors,
+        fallbackMessage: const CardsValidationFailure().message,
+      );
+      return CardsValidationFailure(
+        message: validationMessage,
+        parentException: parentException,
+        stackTrace: stackTrace,
+      );
     }
+    return switch (this) {
+      ValidationFailure() => CardsValidationFailure(
+        parentException: parentException,
+        stackTrace: stackTrace,
+      ),
+      const NoNetworkFailure() ||
+      const ConnectionTimeoutFailure() ||
+      const BadRequestFailure() ||
+      const UnauthorizedFailure() ||
+      const ForbiddenFailure() ||
+      const NotFoundFailure() ||
+      const ConflictFailure() ||
+      const RateLimitedFailure() ||
+      const ServerErrorFailure() ||
+      UnknownNetworkFailure() => CardsRequestFailure(
+        message,
+        parentException: parentException,
+        stackTrace: stackTrace,
+      ),
+      _ => UnknownCardsFailure(
+        parentException: parentException,
+        stackTrace: stackTrace,
+      ),
+    };
   }
 }

--- a/lib/features/cards/data/mappers/saved_card_mapper.dart
+++ b/lib/features/cards/data/mappers/saved_card_mapper.dart
@@ -1,0 +1,15 @@
+import '../../domain/entities/saved_card.dart';
+import '../dto/saved_card_dto.dart';
+
+/// Maps [SavedCardDto] into the cards domain layer.
+extension SavedCardMapper on SavedCardDto {
+  /// Converts [SavedCardDto] to [SavedCard].
+  SavedCard toEntity() => SavedCard(
+    id: id,
+    holderName: cardHolder,
+    lastFour: cardLastFour,
+    expiryMonth: expiryMonth,
+    expiryYear: expiryYear,
+    isDefault: isDefault,
+  );
+}

--- a/lib/features/cards/data/remote/cards_api_client.dart
+++ b/lib/features/cards/data/remote/cards_api_client.dart
@@ -1,0 +1,31 @@
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../../../../core/network/api_paths.dart';
+import '../dto/save_card_request_dto.dart';
+import '../dto/saved_cards_response_dto.dart';
+
+part 'cards_api_client.g.dart';
+
+/// Retrofit API client for saved cards requests and commands.
+@RestApi()
+abstract class CardsApiClient {
+  /// Creates an instance of [CardsApiClient].
+  factory CardsApiClient(Dio dio, {String? baseUrl}) = _CardsApiClient;
+
+  /// Returns all saved cards for the authenticated user.
+  @GET(ApiPaths.paymentCards)
+  Future<SavedCardsResponseDto> getCards();
+
+  /// Saves a new card.
+  @POST(ApiPaths.paymentCardsSave)
+  Future<void> saveCard(@Body() SaveCardRequestDto request);
+
+  /// Marks a card as default.
+  @POST('${ApiPaths.paymentCards}/{cardId}/default')
+  Future<void> setDefaultCard(@Path('cardId') int cardId);
+
+  /// Deletes a saved card.
+  @DELETE('${ApiPaths.paymentCards}/{cardId}')
+  Future<void> deleteCard(@Path('cardId') int cardId);
+}

--- a/lib/features/cards/data/repositories/cards_repository_impl.dart
+++ b/lib/features/cards/data/repositories/cards_repository_impl.dart
@@ -1,0 +1,106 @@
+import 'package:dio/dio.dart';
+
+import '../../../../core/failures/feature/cards/cards_failure.dart';
+import '../../../../core/network/mappers/dio_exception_mapper.dart';
+import '../../../../core/result/result.dart';
+import '../../../../core/utils/logger/app_logger.dart';
+import '../../domain/entities/save_card_payload.dart';
+import '../../domain/entities/saved_card.dart';
+import '../../domain/repositories/cards_repository.dart';
+import '../dto/save_card_request_dto.dart';
+import '../mappers/cards_failure_mapper.dart';
+import '../mappers/saved_card_mapper.dart';
+import '../remote/cards_api_client.dart';
+
+/// Implementation of [CardsRepository].
+final class CardsRepositoryImpl implements CardsRepository {
+  final AppLogger _logger;
+  final CardsApiClient _apiClient;
+
+  /// Creates an instance of [CardsRepositoryImpl].
+  CardsRepositoryImpl(this._logger, this._apiClient);
+
+  @override
+  Future<Result<List<SavedCard>, CardsFailure>> getCards() async {
+    try {
+      final response = await _apiClient.getCards();
+      final defaultCards = <SavedCard>[];
+      final regularCards = <SavedCard>[];
+
+      for (final item in response.data.map((item) => item.toEntity())) {
+        if (item.isDefault) {
+          defaultCards.add(item);
+        } else {
+          regularCards.add(item);
+        }
+      }
+
+      return Result.success([...defaultCards, ...regularCards]);
+    } on DioException catch (e) {
+      final networkFailure = e.toNetworkFailure();
+      return Result.failure(networkFailure.toCardsFailure());
+    } catch (e, s) {
+      _logger.e('GetCards failed with unexpected error', e, s);
+      return Result.failure(
+        UnknownCardsFailure(parentException: e, stackTrace: s),
+      );
+    }
+  }
+
+  @override
+  Future<Result<void, CardsFailure>> saveCard({
+    required SaveCardPayload payload,
+  }) async {
+    try {
+      await _apiClient.saveCard(
+        SaveCardRequestDto(
+          cardNumber: payload.cardNumber,
+          cardHolder: payload.cardHolder,
+          expiryMonth: payload.expiryMonth,
+          expiryYear: payload.expiryYear,
+        ),
+      );
+      return const Result.success(null);
+    } on DioException catch (e) {
+      final networkFailure = e.toNetworkFailure();
+      return Result.failure(networkFailure.toCardsFailure());
+    } catch (e, s) {
+      _logger.e('SaveCard failed with unexpected error', e, s);
+      return Result.failure(
+        UnknownCardsFailure(parentException: e, stackTrace: s),
+      );
+    }
+  }
+
+  @override
+  Future<Result<void, CardsFailure>> setDefaultCard(int cardId) async {
+    try {
+      await _apiClient.setDefaultCard(cardId);
+      return const Result.success(null);
+    } on DioException catch (e) {
+      final networkFailure = e.toNetworkFailure();
+      return Result.failure(networkFailure.toCardsFailure());
+    } catch (e, s) {
+      _logger.e('SetDefaultCard failed with unexpected error', e, s);
+      return Result.failure(
+        UnknownCardsFailure(parentException: e, stackTrace: s),
+      );
+    }
+  }
+
+  @override
+  Future<Result<void, CardsFailure>> deleteCard(int cardId) async {
+    try {
+      await _apiClient.deleteCard(cardId);
+      return const Result.success(null);
+    } on DioException catch (e) {
+      final networkFailure = e.toNetworkFailure();
+      return Result.failure(networkFailure.toCardsFailure());
+    } catch (e, s) {
+      _logger.e('DeleteCard failed with unexpected error', e, s);
+      return Result.failure(
+        UnknownCardsFailure(parentException: e, stackTrace: s),
+      );
+    }
+  }
+}

--- a/lib/features/cards/domain/entities/save_card_payload.dart
+++ b/lib/features/cards/domain/entities/save_card_payload.dart
@@ -1,0 +1,32 @@
+import 'package:equatable/equatable.dart';
+
+/// Typed payload submitted from the save-card dialog.
+final class SaveCardPayload extends Equatable {
+  /// Card number without spaces.
+  final String cardNumber;
+
+  /// Card holder name.
+  final String cardHolder;
+
+  /// Expiry month.
+  final String expiryMonth;
+
+  /// Expiry year.
+  final String expiryYear;
+
+  /// Creates an instance of [SaveCardPayload].
+  const SaveCardPayload({
+    required this.cardNumber,
+    required this.cardHolder,
+    required this.expiryMonth,
+    required this.expiryYear,
+  });
+
+  @override
+  List<Object?> get props => [
+    cardNumber,
+    cardHolder,
+    expiryMonth,
+    expiryYear,
+  ];
+}

--- a/lib/features/cards/domain/entities/saved_card.dart
+++ b/lib/features/cards/domain/entities/saved_card.dart
@@ -1,0 +1,42 @@
+import 'package:equatable/equatable.dart';
+
+/// Saved payment card returned by the cards endpoints.
+final class SavedCard extends Equatable {
+  /// Card identifier.
+  final int id;
+
+  /// Card holder name.
+  final String holderName;
+
+  /// Last four digits of the card number.
+  final String lastFour;
+
+  /// Card expiry month.
+  final String expiryMonth;
+
+  /// Card expiry year.
+  final String expiryYear;
+
+  /// Whether the card is the default one.
+  final bool isDefault;
+
+  /// Creates an instance of [SavedCard].
+  const SavedCard({
+    required this.id,
+    required this.holderName,
+    required this.lastFour,
+    required this.expiryMonth,
+    required this.expiryYear,
+    required this.isDefault,
+  });
+
+  @override
+  List<Object?> get props => [
+    id,
+    holderName,
+    lastFour,
+    expiryMonth,
+    expiryYear,
+    isDefault,
+  ];
+}

--- a/lib/features/cards/domain/repositories/cards_repository.dart
+++ b/lib/features/cards/domain/repositories/cards_repository.dart
@@ -1,0 +1,21 @@
+import '../../../../core/failures/feature/cards/cards_failure.dart';
+import '../../../../core/result/result.dart';
+import '../entities/save_card_payload.dart';
+import '../entities/saved_card.dart';
+
+/// Repository interface for saved cards operations.
+abstract interface class CardsRepository {
+  /// Returns saved cards for the authenticated user.
+  Future<Result<List<SavedCard>, CardsFailure>> getCards();
+
+  /// Saves a new card using the provided [payload].
+  Future<Result<void, CardsFailure>> saveCard({
+    required SaveCardPayload payload,
+  });
+
+  /// Marks a saved card as default.
+  Future<Result<void, CardsFailure>> setDefaultCard(int cardId);
+
+  /// Deletes a saved card by [cardId].
+  Future<Result<void, CardsFailure>> deleteCard(int cardId);
+}

--- a/lib/features/cards/presentation/cubits/cards_cubit.dart
+++ b/lib/features/cards/presentation/cubits/cards_cubit.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../../../core/failures/feature/cards/cards_failure.dart';
+import '../../../../core/result/result.dart';
+import '../../domain/entities/saved_card.dart';
+import '../../domain/repositories/cards_repository.dart';
+
+part 'cards_cubit.freezed.dart';
+part 'cards_state.dart';
+
+/// Cubit that manages loading and refreshing saved cards.
+final class CardsCubit extends Cubit<CardsState> {
+  final CardsRepository _repository;
+
+  /// Creates an instance of [CardsCubit].
+  CardsCubit(this._repository) : super(const CardsState());
+
+  /// Loads saved cards.
+  Future<void> loadCards() async {
+    if (state.isLoading) return;
+
+    emit(
+      state.copyWith(
+        isLoading: true,
+        failure: null,
+      ),
+    );
+
+    final result = await _repository.getCards();
+    if (isClosed) return;
+
+    switch (result) {
+      case Success(:final data):
+        emit(
+          state.copyWith(
+            isLoading: false,
+            cards: data,
+            failure: null,
+          ),
+        );
+      case Failure(:final error):
+        emit(
+          state.copyWith(
+            isLoading: false,
+            failure: error,
+          ),
+        );
+    }
+  }
+}

--- a/lib/features/cards/presentation/cubits/cards_state.dart
+++ b/lib/features/cards/presentation/cubits/cards_state.dart
@@ -1,0 +1,12 @@
+part of 'cards_cubit.dart';
+
+/// State for [CardsCubit].
+@freezed
+abstract class CardsState with _$CardsState {
+  /// Creates an instance of [CardsState].
+  const factory CardsState({
+    @Default(false) bool isLoading,
+    @Default(<SavedCard>[]) List<SavedCard> cards,
+    CardsFailure? failure,
+  }) = _CardsState;
+}

--- a/lib/features/cards/presentation/cubits/delete_card_cubit.dart
+++ b/lib/features/cards/presentation/cubits/delete_card_cubit.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../../../core/failures/feature/cards/cards_failure.dart';
+import '../../../../core/result/result.dart';
+import '../../domain/repositories/cards_repository.dart';
+
+part 'delete_card_cubit.freezed.dart';
+part 'delete_card_state.dart';
+
+/// Cubit that manages the delete-card command flow.
+final class DeleteCardCubit extends Cubit<DeleteCardState> {
+  final CardsRepository _repository;
+
+  /// Creates an instance of [DeleteCardCubit].
+  DeleteCardCubit(this._repository) : super(const DeleteCardState.initial());
+
+  /// Deletes [cardId].
+  Future<void> deleteCard(int cardId) async {
+    final isInProgress = state.maybeWhen(
+      inProgress: (_) => true,
+      orElse: () => false,
+    );
+    if (isInProgress) return;
+
+    emit(DeleteCardState.inProgress(cardId));
+
+    final result = await _repository.deleteCard(cardId);
+    if (isClosed) return;
+
+    switch (result) {
+      case Success():
+        emit(const DeleteCardState.succeed());
+      case Failure(:final error):
+        emit(DeleteCardState.failed(error));
+    }
+  }
+}

--- a/lib/features/cards/presentation/cubits/delete_card_state.dart
+++ b/lib/features/cards/presentation/cubits/delete_card_state.dart
@@ -1,0 +1,17 @@
+part of 'delete_card_cubit.dart';
+
+/// State for [DeleteCardCubit].
+@freezed
+sealed class DeleteCardState with _$DeleteCardState {
+  /// Initial idle state before the delete-card request starts.
+  const factory DeleteCardState.initial() = _Initial;
+
+  /// State emitted while the delete-card request is in progress.
+  const factory DeleteCardState.inProgress(int pendingCardId) = _InProgress;
+
+  /// State emitted when delete-card succeeds.
+  const factory DeleteCardState.succeed() = _Succeed;
+
+  /// State emitted when delete-card fails.
+  const factory DeleteCardState.failed(CardsFailure failure) = _Failed;
+}

--- a/lib/features/cards/presentation/cubits/save_card_cubit.dart
+++ b/lib/features/cards/presentation/cubits/save_card_cubit.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../../../core/failures/feature/cards/cards_failure.dart';
+import '../../../../core/result/result.dart';
+import '../../domain/entities/save_card_payload.dart';
+import '../../domain/repositories/cards_repository.dart';
+
+part 'save_card_cubit.freezed.dart';
+part 'save_card_state.dart';
+
+/// Cubit that manages save-card submit flow.
+final class SaveCardCubit extends Cubit<SaveCardState> {
+  final CardsRepository _repository;
+
+  /// Creates an instance of [SaveCardCubit].
+  SaveCardCubit(this._repository) : super(const SaveCardState.initial());
+
+  /// Saves a new card.
+  Future<void> saveCard({
+    required SaveCardPayload payload,
+  }) async {
+    final isInProgress = state.maybeWhen(
+      inProgress: () => true,
+      orElse: () => false,
+    );
+    if (isInProgress) return;
+
+    emit(const SaveCardState.inProgress());
+
+    final result = await _repository.saveCard(payload: payload);
+    if (isClosed) return;
+
+    switch (result) {
+      case Success():
+        emit(const SaveCardState.succeed());
+      case Failure(:final error):
+        emit(SaveCardState.failed(error));
+    }
+  }
+}

--- a/lib/features/cards/presentation/cubits/save_card_state.dart
+++ b/lib/features/cards/presentation/cubits/save_card_state.dart
@@ -1,0 +1,17 @@
+part of 'save_card_cubit.dart';
+
+/// State for [SaveCardCubit].
+@freezed
+sealed class SaveCardState with _$SaveCardState {
+  /// Initial idle state before the save-card request starts.
+  const factory SaveCardState.initial() = _Initial;
+
+  /// State emitted while the save-card request is in progress.
+  const factory SaveCardState.inProgress() = _InProgress;
+
+  /// State emitted when save-card succeeds.
+  const factory SaveCardState.succeed() = _Succeed;
+
+  /// State emitted when save-card fails.
+  const factory SaveCardState.failed(CardsFailure failure) = _Failed;
+}

--- a/lib/features/cards/presentation/cubits/set_default_card_cubit.dart
+++ b/lib/features/cards/presentation/cubits/set_default_card_cubit.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../../../core/failures/feature/cards/cards_failure.dart';
+import '../../../../core/result/result.dart';
+import '../../domain/repositories/cards_repository.dart';
+
+part 'set_default_card_cubit.freezed.dart';
+part 'set_default_card_state.dart';
+
+/// Cubit that manages the default-card command flow.
+final class SetDefaultCardCubit extends Cubit<SetDefaultCardState> {
+  final CardsRepository _repository;
+
+  /// Creates an instance of [SetDefaultCardCubit].
+  SetDefaultCardCubit(this._repository) : super(const SetDefaultCardState.initial());
+
+  /// Marks [cardId] as default.
+  Future<void> setDefaultCard(int cardId) async {
+    final isInProgress = state.maybeWhen(
+      inProgress: (_) => true,
+      orElse: () => false,
+    );
+    if (isInProgress) return;
+
+    emit(SetDefaultCardState.inProgress(cardId));
+
+    final result = await _repository.setDefaultCard(cardId);
+    if (isClosed) return;
+
+    switch (result) {
+      case Success():
+        emit(const SetDefaultCardState.succeed());
+      case Failure(:final error):
+        emit(SetDefaultCardState.failed(error));
+    }
+  }
+}

--- a/lib/features/cards/presentation/cubits/set_default_card_state.dart
+++ b/lib/features/cards/presentation/cubits/set_default_card_state.dart
@@ -1,0 +1,17 @@
+part of 'set_default_card_cubit.dart';
+
+/// State for [SetDefaultCardCubit].
+@freezed
+sealed class SetDefaultCardState with _$SetDefaultCardState {
+  /// Initial idle state before the default-card request starts.
+  const factory SetDefaultCardState.initial() = _Initial;
+
+  /// State emitted while the default-card request is in progress.
+  const factory SetDefaultCardState.inProgress(int pendingCardId) = _InProgress;
+
+  /// State emitted when default-card succeeds.
+  const factory SetDefaultCardState.succeed() = _Succeed;
+
+  /// State emitted when default-card fails.
+  const factory SetDefaultCardState.failed(CardsFailure failure) = _Failed;
+}

--- a/lib/features/cards/presentation/validators/card_form_validators.dart
+++ b/lib/features/cards/presentation/validators/card_form_validators.dart
@@ -20,7 +20,7 @@ abstract final class CardFormValidators {
 
   /// Validates a card holder.
   static String? cardHolder(String? value) {
-    final trimmed = _trimmed(value);
+    final trimmed = _trimmed(value).toUpperCase();
     if (trimmed.isEmpty) {
       return AppStrings.subscriptionsPaymentCardHolderRequired;
     }

--- a/lib/features/cards/presentation/validators/card_form_validators.dart
+++ b/lib/features/cards/presentation/validators/card_form_validators.dart
@@ -1,0 +1,126 @@
+import '../../../../core/constants/app_strings.dart';
+
+/// Shared validators for saved card form fields.
+abstract final class CardFormValidators {
+  static const _hiddenValidationError = 'invalid';
+  static const _maxFutureYears = 20;
+  static final _cardHolderPattern = RegExp(r'^[A-Z ]+$');
+
+  /// Validates a card number.
+  static String? cardNumber(String? value) {
+    final digits = _digitsOnly(value);
+    if (digits.isEmpty) {
+      return AppStrings.subscriptionsPaymentCardNumberRequired;
+    }
+    if (digits.length != 16) {
+      return AppStrings.subscriptionsPaymentCardNumberInvalid;
+    }
+    return null;
+  }
+
+  /// Validates a card holder.
+  static String? cardHolder(String? value) {
+    final trimmed = _trimmed(value);
+    if (trimmed.isEmpty) {
+      return AppStrings.subscriptionsPaymentCardHolderRequired;
+    }
+    if (!_cardHolderPattern.hasMatch(trimmed)) {
+      return AppStrings.subscriptionsPaymentCardHolderInvalid;
+    }
+    return null;
+  }
+
+  /// Validates a card expiry month.
+  static String? expiryMonth(
+    String? value, {
+    String? yearValue,
+    DateTime? now,
+  }) {
+    final trimmed = _trimmed(value);
+    if (trimmed.isEmpty) {
+      return AppStrings.subscriptionsPaymentExpiryMonthHint;
+    }
+
+    final month = int.tryParse(trimmed);
+    if (month == null || month < 1 || month > 12) {
+      return AppStrings.subscriptionsPaymentExpiryMonthHint;
+    }
+
+    final year = int.tryParse(_trimmed(yearValue));
+    if (year != null) {
+      final currentDate = now ?? DateTime.now();
+      if (_isExpired(month: month, year: year, now: currentDate) ||
+          _isTooFarInFuture(year: year, now: currentDate)) {
+        return _hiddenValidationError;
+      }
+    }
+    return null;
+  }
+
+  /// Validates a card expiry year.
+  static String? expiryYear(
+    String? value, {
+    String? monthValue,
+    DateTime? now,
+  }) {
+    final trimmed = _trimmed(value);
+    if (trimmed.isEmpty) {
+      return AppStrings.subscriptionsPaymentExpiryYearHint;
+    }
+    if (trimmed.length != 4) {
+      return AppStrings.subscriptionsPaymentExpiryYearHint;
+    }
+
+    final year = int.tryParse(trimmed);
+    if (year == null) {
+      return AppStrings.subscriptionsPaymentExpiryYearHint;
+    }
+
+    final currentDate = now ?? DateTime.now();
+    if (year < currentDate.year || _isTooFarInFuture(year: year, now: currentDate)) {
+      return _hiddenValidationError;
+    }
+
+    final month = int.tryParse(_trimmed(monthValue));
+    if (month != null &&
+        month >= 1 &&
+        month <= 12 &&
+        _isExpired(month: month, year: year, now: currentDate)) {
+      return _hiddenValidationError;
+    }
+    return null;
+  }
+
+  /// Validates a card CVV.
+  static String? cvv(String? value) {
+    final trimmed = _trimmed(value);
+    if (trimmed.isEmpty) {
+      return AppStrings.subscriptionsPaymentCvvHint;
+    }
+    if (trimmed.length != 3 || int.tryParse(trimmed) == null) {
+      return AppStrings.subscriptionsPaymentCvvHint;
+    }
+    return null;
+  }
+
+  static String _trimmed(String? value) => value?.trim() ?? '';
+
+  static String _digitsOnly(String? value) => (value ?? '').replaceAll(RegExp(r'\D'), '');
+
+  static bool _isExpired({
+    required int month,
+    required int year,
+    required DateTime now,
+  }) {
+    if (year < now.year) return true;
+    if (year == now.year && month < now.month) return true;
+    return false;
+  }
+
+  static bool _isTooFarInFuture({
+    required int year,
+    required DateTime now,
+  }) {
+    return year > now.year + _maxFutureYears;
+  }
+}

--- a/lib/features/cards/presentation/widgets/card_form_text_field.dart
+++ b/lib/features/cards/presentation/widgets/card_form_text_field.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../../../../uikit/themes/colors/app_color_theme.dart';
+import '../../../../uikit/themes/text/app_text_theme.dart';
+
+/// Cards-specific text field used only inside the save-card flow.
+class CardFormTextField extends StatelessWidget {
+  /// Text controller.
+  final TextEditingController controller;
+
+  /// Whether the field is enabled.
+  final bool enabled;
+
+  /// Field label shown above the input.
+  final String labelText;
+
+  /// Optional label color override.
+  final Color? labelColor;
+
+  /// Placeholder text.
+  final String? hintText;
+
+  /// Optional semantics label when the visible label is hidden.
+  final String? semanticsLabel;
+
+  /// Keyboard configuration.
+  final TextInputType keyboardType;
+
+  /// Keyboard action button.
+  final TextInputAction textInputAction;
+
+  /// Optional validator.
+  final String? Function(String?)? validator;
+
+  /// Optional submit callback.
+  final ValueChanged<String>? onFieldSubmitted;
+
+  /// Optional input formatters.
+  final List<TextInputFormatter>? inputFormatters;
+
+  /// Whether to hide text.
+  final bool obscureText;
+
+  /// Whether the visible label should be rendered.
+  final bool showLabel;
+
+  /// Whether validation error text should be shown.
+  final bool showErrorText;
+
+  /// Creates an instance of [CardFormTextField].
+  const CardFormTextField({
+    required this.controller,
+    required this.enabled,
+    required this.labelText,
+    required this.keyboardType,
+    required this.textInputAction,
+    this.labelColor,
+    this.hintText,
+    this.semanticsLabel,
+    this.validator,
+    this.onFieldSubmitted,
+    this.inputFormatters,
+    this.obscureText = false,
+    this.showLabel = true,
+    this.showErrorText = true,
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorTheme = AppColorTheme.of(context);
+    final textTheme = AppTextTheme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (showLabel) ...[
+          ExcludeSemantics(
+            child: Text(
+              labelText,
+              style: textTheme.label.copyWith(color: labelColor ?? colorTheme.onSurface),
+            ),
+          ),
+          const SizedBox(height: 4),
+        ],
+        Semantics(
+          label: semanticsLabel ?? labelText,
+          textField: true,
+          child: TextFormField(
+            controller: controller,
+            enabled: enabled,
+            keyboardType: keyboardType,
+            obscureText: obscureText,
+            textInputAction: textInputAction,
+            onFieldSubmitted: onFieldSubmitted,
+            inputFormatters: inputFormatters,
+            style: textTheme.body.copyWith(color: colorTheme.onSurface),
+            cursorColor: colorTheme.primary,
+            decoration: InputDecoration(
+              hintText: hintText,
+              errorStyle: showErrorText
+                  ? null
+                  : const TextStyle(
+                      fontSize: 0,
+                      height: 0,
+                      color: Colors.transparent,
+                    ),
+            ),
+            validator: validator,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/cards/presentation/widgets/save_card_dialog.dart
+++ b/lib/features/cards/presentation/widgets/save_card_dialog.dart
@@ -51,6 +51,8 @@ class _SaveCardDialogState extends State<SaveCardDialog> {
   final _expiryYearController = TextEditingController();
   final _cvvController = TextEditingController();
 
+  String get _normalizedCardHolder => _cardHolderController.text.trim().toUpperCase();
+
   @override
   void initState() {
     super.initState();
@@ -100,7 +102,7 @@ class _SaveCardDialogState extends State<SaveCardDialog> {
     context.read<SaveCardCubit>().saveCard(
       payload: SaveCardPayload(
         cardNumber: _cardNumberController.text.replaceAll(RegExp(r'\D'), ''),
-        cardHolder: _cardHolderController.text.trim(),
+        cardHolder: _normalizedCardHolder,
         expiryMonth: _expiryMonthController.text.trim(),
         expiryYear: _expiryYearController.text.trim(),
       ),
@@ -160,6 +162,7 @@ class _SaveCardDialogState extends State<SaveCardDialog> {
                       enabled: !isInProgress,
                       keyboardType: TextInputType.name,
                       textInputAction: TextInputAction.next,
+                      inputFormatters: [const _CardHolderTextInputFormatter()],
                       validator: CardFormValidators.cardHolder,
                     ),
                     const SizedBox(height: 12),
@@ -274,7 +277,7 @@ class _SaveCardDialogState extends State<SaveCardDialog> {
               right: 0,
               child: _CardPreview(
                 previewCardNumberController: _previewCardNumberController,
-                cardHolderValue: _cardHolderController.text,
+                cardHolderValue: _normalizedCardHolder,
                 expiryMonthValue: _expiryMonthController.text.trim(),
                 expiryYearValue: _expiryYearController.text.trim(),
               ),
@@ -468,6 +471,18 @@ final class _CardNumberTextInputFormatter extends TextInputFormatter {
   }
 
   bool _isDigit(int codeUnit) => codeUnit >= 48 && codeUnit <= 57;
+}
+
+final class _CardHolderTextInputFormatter extends TextInputFormatter {
+  const _CardHolderTextInputFormatter();
+
+  @override
+  TextEditingValue formatEditUpdate(
+    TextEditingValue oldValue,
+    TextEditingValue newValue,
+  ) {
+    return newValue.copyWith(text: newValue.text.toUpperCase());
+  }
 }
 
 extension on String {

--- a/lib/features/cards/presentation/widgets/save_card_dialog.dart
+++ b/lib/features/cards/presentation/widgets/save_card_dialog.dart
@@ -1,0 +1,437 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../core/constants/app_assets.dart';
+import '../../../../core/constants/app_strings.dart';
+import '../../../../uikit/buttons/button_state.dart';
+import '../../../../uikit/buttons/main_button.dart';
+import '../../../../uikit/buttons/secondary_button.dart';
+import '../../../../uikit/dialogs/app_feedback_dialog.dart';
+import '../../../../uikit/images/svg_picture_widget.dart';
+import '../../../../uikit/themes/colors/app_color_theme.dart';
+import '../../../../uikit/themes/text/app_text_theme.dart';
+import '../../../profile/presentation/widgets/profile_dialog_shell.dart';
+import '../../domain/entities/save_card_payload.dart';
+import '../cubits/save_card_cubit.dart';
+import '../validators/card_form_validators.dart';
+import 'card_form_text_field.dart';
+
+/// Opens the save-card dialog.
+Future<bool?> showSaveCardDialog(
+  BuildContext context, {
+  required SaveCardCubit saveCardCubit,
+}) {
+  return showProfileDialog<bool>(
+    context,
+    insetPadding: const EdgeInsets.symmetric(horizontal: 24),
+    contentPadding: EdgeInsets.zero,
+    child: BlocProvider.value(
+      value: saveCardCubit,
+      child: const SaveCardDialog(),
+    ),
+  );
+}
+
+/// Dialog with manual card form for saving a card.
+class SaveCardDialog extends StatefulWidget {
+  /// Creates an instance of [SaveCardDialog].
+  const SaveCardDialog({super.key});
+
+  @override
+  State<SaveCardDialog> createState() => _SaveCardDialogState();
+}
+
+class _SaveCardDialogState extends State<SaveCardDialog> {
+  final _formKey = GlobalKey<FormState>();
+  final _cardNumberController = TextEditingController();
+  final _previewCardNumberController = TextEditingController();
+  final _cardHolderController = TextEditingController();
+  final _expiryMonthController = TextEditingController();
+  final _expiryYearController = TextEditingController();
+  final _cvvController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _cardNumberController.addListener(_syncPreviewCardNumber);
+    _cardNumberController.addListener(_handlePreviewChanged);
+    _cardHolderController.addListener(_handlePreviewChanged);
+    _expiryMonthController.addListener(_handlePreviewChanged);
+    _expiryYearController.addListener(_handlePreviewChanged);
+  }
+
+  @override
+  void dispose() {
+    _cardNumberController
+      ..removeListener(_syncPreviewCardNumber)
+      ..removeListener(_handlePreviewChanged)
+      ..dispose();
+    _cardHolderController.removeListener(_handlePreviewChanged);
+    _previewCardNumberController.dispose();
+    _cardHolderController.dispose();
+    _expiryMonthController.removeListener(_handlePreviewChanged);
+    _expiryMonthController.dispose();
+    _expiryYearController.removeListener(_handlePreviewChanged);
+    _expiryYearController.dispose();
+    _cvvController.dispose();
+    super.dispose();
+  }
+
+  void _handlePreviewChanged() {
+    if (!mounted) return;
+    setState(() {});
+  }
+
+  void _syncPreviewCardNumber() {
+    final digits = _cardNumberController.text.replaceAll(RegExp(r'\D'), '');
+    final chunks = <String>[];
+    for (var index = 0; index < digits.length; index += 4) {
+      final end = (index + 4).clamp(0, digits.length);
+      chunks.add(digits.substring(index, end));
+    }
+    _previewCardNumberController.text = chunks.join(' ');
+  }
+
+  void _submit() {
+    final form = _formKey.currentState;
+    if (form == null || !form.validate()) return;
+
+    context.read<SaveCardCubit>().saveCard(
+      payload: SaveCardPayload(
+        cardNumber: _cardNumberController.text.replaceAll(RegExp(r'\D'), ''),
+        cardHolder: _cardHolderController.text.trim(),
+        expiryMonth: _expiryMonthController.text.trim(),
+        expiryYear: _expiryYearController.text.trim(),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocConsumer<SaveCardCubit, SaveCardState>(
+      listener: (context, state) {
+        state.whenOrNull(
+          succeed: () => Navigator.of(context).pop(true),
+          failed: (failure) {
+            if (failure.message.isEmpty) return;
+            showAppFeedbackDialog(
+              context,
+              title: AppStrings.feedbackErrorTitle,
+              message: failure.message,
+            );
+          },
+        );
+      },
+      builder: (context, state) {
+        final isInProgress = state.maybeWhen(
+          inProgress: () => true,
+          orElse: () => false,
+        );
+        final colorTheme = AppColorTheme.of(context);
+        return Stack(
+          clipBehavior: Clip.none,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(28, 83, 28, 40),
+              child: Form(
+                key: _formKey,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    CardFormTextField(
+                      controller: _cardNumberController,
+                      labelText: AppStrings.subscriptionsPaymentCardNumberLabel,
+                      labelColor: colorTheme.hint,
+                      hintText: AppStrings.subscriptionsPaymentCardNumberHint,
+                      enabled: !isInProgress,
+                      keyboardType: TextInputType.number,
+                      textInputAction: TextInputAction.next,
+                      inputFormatters: [const _CardNumberTextInputFormatter()],
+                      validator: CardFormValidators.cardNumber,
+                    ),
+                    const SizedBox(height: 12),
+                    CardFormTextField(
+                      controller: _cardHolderController,
+                      labelText: AppStrings.subscriptionsPaymentCardHolderLabel,
+                      labelColor: colorTheme.hint,
+                      hintText: AppStrings.subscriptionsPaymentCardHolderHint,
+                      enabled: !isInProgress,
+                      keyboardType: TextInputType.name,
+                      textInputAction: TextInputAction.next,
+                      validator: CardFormValidators.cardHolder,
+                    ),
+                    const SizedBox(height: 12),
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Expanded(
+                          flex: 2,
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              ExcludeSemantics(
+                                child: Text(
+                                  AppStrings.subscriptionsPaymentExpiryLabel,
+                                  style: AppTextTheme.of(context).label.copyWith(
+                                    color: colorTheme.hint,
+                                  ),
+                                ),
+                              ),
+                              const SizedBox(height: 4),
+                              Row(
+                                children: [
+                                  Expanded(
+                                    child: CardFormTextField(
+                                      controller: _expiryMonthController,
+                                      labelText: AppStrings.subscriptionsPaymentExpiryLabel,
+                                      semanticsLabel: AppStrings.subscriptionsPaymentExpiryLabel,
+                                      hintText: AppStrings.subscriptionsPaymentExpiryMonthHint,
+                                      showErrorText: false,
+                                      enabled: !isInProgress,
+                                      keyboardType: TextInputType.number,
+                                      textInputAction: TextInputAction.next,
+                                      showLabel: false,
+                                      inputFormatters: [
+                                        FilteringTextInputFormatter.digitsOnly,
+                                        LengthLimitingTextInputFormatter(2),
+                                      ],
+                                      validator: (value) => CardFormValidators.expiryMonth(
+                                        value,
+                                        yearValue: _expiryYearController.text,
+                                      ),
+                                    ),
+                                  ),
+                                  const SizedBox(width: 12),
+                                  Expanded(
+                                    child: CardFormTextField(
+                                      controller: _expiryYearController,
+                                      labelText: AppStrings.subscriptionsPaymentYearLabel,
+                                      semanticsLabel: AppStrings.subscriptionsPaymentYearLabel,
+                                      hintText: AppStrings.subscriptionsPaymentExpiryYearHint,
+                                      showErrorText: false,
+                                      enabled: !isInProgress,
+                                      keyboardType: TextInputType.number,
+                                      textInputAction: TextInputAction.next,
+                                      showLabel: false,
+                                      inputFormatters: [
+                                        FilteringTextInputFormatter.digitsOnly,
+                                        LengthLimitingTextInputFormatter(4),
+                                      ],
+                                      validator: (value) => CardFormValidators.expiryYear(
+                                        value,
+                                        monthValue: _expiryMonthController.text,
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ],
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: CardFormTextField(
+                            controller: _cvvController,
+                            labelText: AppStrings.subscriptionsPaymentCvvLabel,
+                            labelColor: colorTheme.hint,
+                            hintText: AppStrings.subscriptionsPaymentCvvHint,
+                            showErrorText: false,
+                            enabled: !isInProgress,
+                            keyboardType: TextInputType.number,
+                            textInputAction: TextInputAction.done,
+                            obscureText: true,
+                            inputFormatters: [
+                              FilteringTextInputFormatter.digitsOnly,
+                              LengthLimitingTextInputFormatter(3),
+                            ],
+                            validator: CardFormValidators.cvv,
+                            onFieldSubmitted: (_) => _submit(),
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 36),
+                    MainButton(
+                      state: isInProgress ? ButtonState.loading : ButtonState.enabled,
+                      onPressed: _submit,
+                      child: const Text(AppStrings.cardsAddButton),
+                    ),
+                    const SizedBox(height: 12),
+                    SecondaryButton(
+                      state: isInProgress ? ButtonState.disabled : ButtonState.enabled,
+                      onPressed: () => Navigator.of(context).pop(false),
+                      child: const Text(AppStrings.profileCancelButton),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            Positioned(
+              left: 18,
+              right: 18,
+              top: -32,
+              child: _CardPreview(
+                previewCardNumberController: _previewCardNumberController,
+                cardHolderValue: _cardHolderController.text.trim(),
+                expiryMonthValue: _expiryMonthController.text.trim(),
+                expiryYearValue: _expiryYearController.text.trim(),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+final class _CardPreview extends StatelessWidget {
+  final TextEditingController previewCardNumberController;
+  final String cardHolderValue;
+  final String expiryMonthValue;
+  final String expiryYearValue;
+
+  const _CardPreview({
+    required this.previewCardNumberController,
+    required this.cardHolderValue,
+    required this.expiryMonthValue,
+    required this.expiryYearValue,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorTheme = AppColorTheme.of(context);
+    final textTheme = AppTextTheme.of(context);
+    return Stack(
+      children: [
+        const SvgPictureWidget.icon(
+          AppAssets.iconCardBig,
+          fit: BoxFit.fitWidth,
+        ),
+        Positioned.fill(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(24, 51, 24, 12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                _PreviewNumberField(controller: previewCardNumberController),
+                const SizedBox(height: 12),
+                Expanded(
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          mainAxisAlignment: MainAxisAlignment.end,
+                          children: [
+                            Text(
+                              AppStrings.subscriptionsPaymentCardHolderLabel,
+                              style: textTheme.label.copyWith(color: colorTheme.onPrimary),
+                            ),
+                            const SizedBox(height: 12),
+                            Text(
+                              cardHolderValue.isEmpty
+                                  ? AppStrings.subscriptionsPaymentCardHolderHint
+                                  : cardHolderValue,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: textTheme.bodyMedium.copyWith(color: colorTheme.onPrimary),
+                            ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(width: 16),
+                      Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisAlignment: MainAxisAlignment.end,
+                        children: [
+                          Text(
+                            AppStrings.subscriptionsPaymentPreviewExpiryLabel,
+                            style: textTheme.label.copyWith(color: colorTheme.onPrimary),
+                          ),
+                          const SizedBox(height: 12),
+                          Text(
+                            '${expiryMonthValue.isEmpty ? AppStrings.subscriptionsPaymentPreviewExpiryMonthLabel : expiryMonthValue}/'
+                            '${expiryYearValue.isEmpty ? AppStrings.subscriptionsPaymentPreviewExpiryYearLabel : expiryYearValue.substring(expiryYearValue.length > 2 ? expiryYearValue.length - 2 : 0)}',
+                            style: textTheme.bodyMedium.copyWith(color: colorTheme.onPrimary),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+final class _PreviewNumberField extends StatelessWidget {
+  final TextEditingController controller;
+
+  const _PreviewNumberField({
+    required this.controller,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorTheme = AppColorTheme.of(context);
+    final textTheme = AppTextTheme.of(context);
+
+    return Semantics(
+      label: AppStrings.subscriptionsPaymentCardNumberLabel,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(15),
+          border: Border.all(color: colorTheme.outline),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
+          child: Text(
+            controller.text.isEmpty
+                ? AppStrings.subscriptionsPaymentCardNumberHint
+                : controller.text,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: textTheme.body.copyWith(
+              color: controller.text.isEmpty ? colorTheme.outline : colorTheme.onSurface,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+final class _CardNumberTextInputFormatter extends TextInputFormatter {
+  const _CardNumberTextInputFormatter();
+
+  @override
+  TextEditingValue formatEditUpdate(
+    TextEditingValue oldValue,
+    TextEditingValue newValue,
+  ) {
+    final digits = newValue.text.replaceAll(RegExp(r'\D'), '');
+    final limitedDigits = digits.length > 16 ? digits.substring(0, 16) : digits;
+    final buffer = StringBuffer();
+
+    for (var index = 0; index < limitedDigits.length; index++) {
+      if (index > 0 && index % 4 == 0) {
+        buffer.write(' ');
+      }
+      buffer.write(limitedDigits[index]);
+    }
+
+    final formatted = buffer.toString();
+    return TextEditingValue(
+      text: formatted,
+      selection: TextSelection.collapsed(offset: formatted.length),
+    );
+  }
+}

--- a/lib/features/cards/presentation/widgets/save_card_dialog.dart
+++ b/lib/features/cards/presentation/widgets/save_card_dialog.dart
@@ -269,12 +269,12 @@ class _SaveCardDialogState extends State<SaveCardDialog> {
               ),
             ),
             Positioned(
-              left: 18,
-              right: 18,
-              top: -32,
+              top: -100,
+              left: 0,
+              right: 0,
               child: _CardPreview(
                 previewCardNumberController: _previewCardNumberController,
-                cardHolderValue: _cardHolderController.text.trim(),
+                cardHolderValue: _cardHolderController.text,
                 expiryMonthValue: _expiryMonthController.text.trim(),
                 expiryYearValue: _expiryYearController.text.trim(),
               ),
@@ -305,65 +305,71 @@ final class _CardPreview extends StatelessWidget {
     final textTheme = AppTextTheme.of(context);
     return Stack(
       children: [
-        const SvgPictureWidget.icon(
-          AppAssets.iconCardBig,
-          fit: BoxFit.fitWidth,
+        const Positioned.fill(
+          child: IgnorePointer(
+            child: ExcludeSemantics(
+              child: SvgPictureWidget.icon(AppAssets.iconCardBig),
+            ),
+          ),
         ),
-        Positioned.fill(
-          child: Padding(
-            padding: const EdgeInsets.fromLTRB(24, 51, 24, 12),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                _PreviewNumberField(controller: previewCardNumberController),
-                const SizedBox(height: 12),
-                Expanded(
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.end,
-                    children: [
-                      Expanded(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          mainAxisAlignment: MainAxisAlignment.end,
-                          children: [
-                            Text(
-                              AppStrings.subscriptionsPaymentCardHolderLabel,
-                              style: textTheme.label.copyWith(color: colorTheme.onPrimary),
-                            ),
-                            const SizedBox(height: 12),
-                            Text(
-                              cardHolderValue.isEmpty
-                                  ? AppStrings.subscriptionsPaymentCardHolderHint
-                                  : cardHolderValue,
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                              style: textTheme.bodyMedium.copyWith(color: colorTheme.onPrimary),
-                            ),
-                          ],
-                        ),
-                      ),
-                      const SizedBox(width: 16),
-                      Column(
+        Padding(
+          padding: const EdgeInsets.fromLTRB(24, 51, 24, 12),
+          child: Column(
+            children: [
+              SizedBox(
+                width: 224,
+                child: _PreviewNumberField(controller: previewCardNumberController),
+              ),
+              const SizedBox(height: 12),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 48),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
-                        mainAxisAlignment: MainAxisAlignment.end,
                         children: [
                           Text(
-                            AppStrings.subscriptionsPaymentPreviewExpiryLabel,
+                            AppStrings.subscriptionsPaymentCardHolderLabel,
                             style: textTheme.label.copyWith(color: colorTheme.onPrimary),
                           ),
-                          const SizedBox(height: 12),
+                          const SizedBox(height: 4),
                           Text(
-                            '${expiryMonthValue.isEmpty ? AppStrings.subscriptionsPaymentPreviewExpiryMonthLabel : expiryMonthValue}/'
-                            '${expiryYearValue.isEmpty ? AppStrings.subscriptionsPaymentPreviewExpiryYearLabel : expiryYearValue.substring(expiryYearValue.length > 2 ? expiryYearValue.length - 2 : 0)}',
-                            style: textTheme.bodyMedium.copyWith(color: colorTheme.onPrimary),
+                            cardHolderValue.isEmpty
+                                ? AppStrings.subscriptionsPaymentCardHolderHint
+                                : cardHolderValue,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: textTheme.label.copyWith(color: colorTheme.onPrimary),
                           ),
                         ],
                       ),
-                    ],
-                  ),
+                    ),
+                    const SizedBox(width: 12),
+                    Column(
+                      mainAxisAlignment: MainAxisAlignment.end,
+                      children: [
+                        Text(
+                          AppStrings.subscriptionsPaymentPreviewExpiryLabel,
+                          style: textTheme.label.copyWith(color: colorTheme.onPrimary),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          [expiryMonthValue, expiryYearValue]
+                              .where((value) => value.isNotEmpty)
+                              .join('/')
+                              .ifEmpty(
+                                '${AppStrings.subscriptionsPaymentPreviewExpiryMonthLabel}/'
+                                '${AppStrings.subscriptionsPaymentPreviewExpiryYearLabel}',
+                              ),
+                          style: textTheme.label.copyWith(color: colorTheme.onPrimary),
+                        ),
+                      ],
+                    ),
+                  ],
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
         ),
       ],
@@ -382,26 +388,25 @@ final class _PreviewNumberField extends StatelessWidget {
   Widget build(BuildContext context) {
     final colorTheme = AppColorTheme.of(context);
     final textTheme = AppTextTheme.of(context);
+    final displayText = controller.text.isEmpty
+        ? AppStrings.subscriptionsPaymentCardNumberHint
+        : controller.text;
+    final textColor = controller.text.isEmpty ? colorTheme.outline : colorTheme.onSurface;
 
     return Semantics(
       label: AppStrings.subscriptionsPaymentCardNumberLabel,
+      textField: true,
       child: DecoratedBox(
         decoration: BoxDecoration(
-          color: Colors.white,
-          borderRadius: BorderRadius.circular(15),
+          color: colorTheme.surface,
+          borderRadius: BorderRadius.circular(8),
           border: Border.all(color: colorTheme.outline),
         ),
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
           child: Text(
-            controller.text.isEmpty
-                ? AppStrings.subscriptionsPaymentCardNumberHint
-                : controller.text,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: textTheme.body.copyWith(
-              color: controller.text.isEmpty ? colorTheme.outline : colorTheme.onSurface,
-            ),
+            displayText,
+            style: textTheme.body.copyWith(color: textColor),
           ),
         ),
       ),
@@ -434,4 +439,8 @@ final class _CardNumberTextInputFormatter extends TextInputFormatter {
       selection: TextSelection.collapsed(offset: formatted.length),
     );
   }
+}
+
+extension on String {
+  String ifEmpty(String fallback) => isEmpty ? fallback : this;
 }

--- a/lib/features/cards/presentation/widgets/save_card_dialog.dart
+++ b/lib/features/cards/presentation/widgets/save_card_dialog.dart
@@ -424,6 +424,10 @@ final class _CardNumberTextInputFormatter extends TextInputFormatter {
   ) {
     final digits = newValue.text.replaceAll(RegExp(r'\D'), '');
     final limitedDigits = digits.length > 16 ? digits.substring(0, 16) : digits;
+    final rawSelectionOffset = _countDigitsBefore(
+      newValue.text,
+      newValue.selection.baseOffset,
+    ).clamp(0, limitedDigits.length);
     final buffer = StringBuffer();
 
     for (var index = 0; index < limitedDigits.length; index++) {
@@ -436,9 +440,34 @@ final class _CardNumberTextInputFormatter extends TextInputFormatter {
     final formatted = buffer.toString();
     return TextEditingValue(
       text: formatted,
-      selection: TextSelection.collapsed(offset: formatted.length),
+      selection: TextSelection.collapsed(
+        offset: _formattedSelectionOffset(
+          rawSelectionOffset,
+          formatted.length,
+        ),
+      ),
     );
   }
+
+  int _countDigitsBefore(String value, int offset) {
+    if (offset <= 0) return 0;
+
+    final clampedOffset = offset.clamp(0, value.length);
+    var count = 0;
+    for (var index = 0; index < clampedOffset; index++) {
+      if (_isDigit(value.codeUnitAt(index))) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  int _formattedSelectionOffset(int rawOffset, int formattedLength) {
+    final spacesBefore = rawOffset == 0 ? 0 : rawOffset ~/ 4;
+    return (rawOffset + spacesBefore).clamp(0, formattedLength);
+  }
+
+  bool _isDigit(int codeUnit) => codeUnit >= 48 && codeUnit <= 57;
 }
 
 extension on String {

--- a/lib/features/profile/presentation/pages/profile_page.dart
+++ b/lib/features/profile/presentation/pages/profile_page.dart
@@ -22,6 +22,7 @@ import '../widgets/change_password_dialog.dart';
 import '../widgets/current_phase_section_widget.dart';
 import '../widgets/edit_profile_dialog.dart';
 import '../widgets/profile_bottom_section_widget.dart';
+import '../widgets/profile_cards_section_widget.dart';
 import '../widgets/profile_parameters_section_widget.dart';
 import '../widgets/profile_subscription_section_widget.dart';
 import '../widgets/stats/profile_history_dialog.dart';
@@ -137,6 +138,8 @@ class ProfilePage extends StatelessWidget {
                   ProfileSubscriptionSectionWidget(
                     activeSubscription: state.historySnapshot?.activeSubscription,
                   ),
+                  const SizedBox(height: 36),
+                  const ProfileCardsSectionWidget(),
                   const SizedBox(height: 36),
                   const CurrentPhaseSectionWidget(),
                   const SizedBox(height: 36),

--- a/lib/features/profile/presentation/pages/profile_page_builder.dart
+++ b/lib/features/profile/presentation/pages/profile_page_builder.dart
@@ -6,6 +6,11 @@ import '../../../auth/domain/entities/user.dart';
 import '../../../auth/domain/repositories/auth_repository.dart';
 import '../../../auth/presentation/cubits/auth_session_cubit.dart';
 import '../../../auth/presentation/cubits/logout_cubit.dart';
+import '../../../cards/domain/repositories/cards_repository.dart';
+import '../../../cards/presentation/cubits/cards_cubit.dart';
+import '../../../cards/presentation/cubits/delete_card_cubit.dart';
+import '../../../cards/presentation/cubits/save_card_cubit.dart';
+import '../../../cards/presentation/cubits/set_default_card_cubit.dart';
 import '../../../subscriptions/domain/repositories/subscriptions_repository.dart';
 import '../../../subscriptions/presentation/cubits/cancel_subscription_cubit.dart';
 import '../../domain/repositories/profile_parameters_repository.dart';
@@ -54,6 +59,20 @@ class ProfilePageBuilder extends StatelessWidget {
           create: (_) => ProfileSubscriptionCubit(
             di<SubscriptionsRepository>(),
           ),
+        ),
+        BlocProvider(
+          create: (_) => CardsCubit(
+            di<CardsRepository>(),
+          )..loadCards(),
+        ),
+        BlocProvider(
+          create: (_) => SaveCardCubit(di<CardsRepository>()),
+        ),
+        BlocProvider(
+          create: (_) => SetDefaultCardCubit(di<CardsRepository>()),
+        ),
+        BlocProvider(
+          create: (_) => DeleteCardCubit(di<CardsRepository>()),
         ),
         BlocProvider.value(
           value: di<ProfileRefreshCubit>(),

--- a/lib/features/profile/presentation/widgets/profile_cards_section_widget.dart
+++ b/lib/features/profile/presentation/widgets/profile_cards_section_widget.dart
@@ -1,0 +1,486 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../../core/constants/app_assets.dart';
+import '../../../../../core/constants/app_strings.dart';
+import '../../../../../uikit/buttons/button_state.dart';
+import '../../../../../uikit/buttons/main_button.dart';
+import '../../../../../uikit/buttons/secondary_button.dart';
+import '../../../../../uikit/cards/app_card.dart';
+import '../../../../../uikit/dialogs/app_action_dialog.dart';
+import '../../../../../uikit/dialogs/app_feedback_dialog.dart';
+import '../../../../../uikit/images/svg_picture_widget.dart';
+import '../../../../../uikit/themes/colors/app_color_theme.dart';
+import '../../../../../uikit/themes/text/app_text_theme.dart';
+import '../../../cards/domain/entities/saved_card.dart';
+import '../../../cards/presentation/cubits/cards_cubit.dart';
+import '../../../cards/presentation/cubits/delete_card_cubit.dart';
+import '../../../cards/presentation/cubits/save_card_cubit.dart';
+import '../../../cards/presentation/cubits/set_default_card_cubit.dart';
+import '../../../cards/presentation/widgets/save_card_dialog.dart';
+
+/// Cards section rendered inside `/profile`.
+class ProfileCardsSectionWidget extends StatefulWidget {
+  /// Creates an instance of [ProfileCardsSectionWidget].
+  const ProfileCardsSectionWidget({super.key});
+
+  @override
+  State<ProfileCardsSectionWidget> createState() => _ProfileCardsSectionWidgetState();
+}
+
+class _ProfileCardsSectionWidgetState extends State<ProfileCardsSectionWidget> {
+  bool _isDeleteDialogOpen = false;
+
+  Future<void> _openSaveCardDialog(List<SavedCard> cards) async {
+    if (cards.length >= 3) {
+      await showAppFeedbackDialog(
+        context,
+        title: AppStrings.cardsAddLimitTitle,
+        message: AppStrings.cardsAddLimitMessage,
+      );
+      return;
+    }
+
+    final didSave = await showSaveCardDialog(
+      context,
+      saveCardCubit: context.read<SaveCardCubit>(),
+    );
+    if (!mounted || didSave != true) return;
+
+    unawaited(context.read<CardsCubit>().loadCards());
+  }
+
+  Future<void> _openDeleteDialog(int cardId) async {
+    if (_isDeleteDialogOpen) return;
+    _isDeleteDialogOpen = true;
+    final deleteCardCubit = context.read<DeleteCardCubit>();
+    try {
+      await showAppActionDialog(
+        context,
+        title: AppStrings.cardsDeleteTitle,
+        description: AppStrings.cardsDeleteDescription,
+        primaryAction: BlocProvider.value(
+          value: deleteCardCubit,
+          child: BlocBuilder<DeleteCardCubit, DeleteCardState>(
+            builder: (context, state) {
+              final isInProgress = state.maybeWhen(
+                inProgress: (pendingCardId) => pendingCardId == cardId,
+                orElse: () => false,
+              );
+              return MainButton(
+                state: isInProgress ? ButtonState.loading : ButtonState.enabled,
+                onPressed: () => context.read<DeleteCardCubit>().deleteCard(cardId),
+                child: const Text(AppStrings.cardsDeleteConfirmButton),
+              );
+            },
+          ),
+        ),
+        secondaryAction: BlocProvider.value(
+          value: deleteCardCubit,
+          child: BlocBuilder<DeleteCardCubit, DeleteCardState>(
+            builder: (context, state) {
+              final isInProgress = state.maybeWhen(
+                inProgress: (_) => true,
+                orElse: () => false,
+              );
+              return SecondaryButton(
+                state: isInProgress ? ButtonState.disabled : ButtonState.enabled,
+                onPressed: _closeActiveDialog,
+                child: const Text(AppStrings.profileCancelButton),
+              );
+            },
+          ),
+        ),
+      );
+    } finally {
+      _isDeleteDialogOpen = false;
+    }
+  }
+
+  void _closeActiveDialog() {
+    final navigator = Navigator.of(context, rootNavigator: true);
+    if (!navigator.canPop()) return;
+
+    Route<dynamic>? topRoute;
+    navigator.popUntil((route) {
+      topRoute = route;
+      return true;
+    });
+    if (topRoute is! PopupRoute<dynamic>) return;
+
+    navigator.pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MultiBlocListener(
+      listeners: [
+        BlocListener<SetDefaultCardCubit, SetDefaultCardState>(
+          listener: (context, state) {
+            state.whenOrNull(
+              succeed: () => unawaited(context.read<CardsCubit>().loadCards()),
+              failed: (failure) {
+                if (failure.message.isEmpty) return;
+                unawaited(
+                  showAppFeedbackDialog(
+                    context,
+                    title: AppStrings.feedbackErrorTitle,
+                    message: failure.message,
+                  ),
+                );
+              },
+            );
+          },
+        ),
+        BlocListener<DeleteCardCubit, DeleteCardState>(
+          listener: (context, state) {
+            state.whenOrNull(
+              succeed: () {
+                _closeActiveDialog();
+                unawaited(context.read<CardsCubit>().loadCards());
+              },
+              failed: (failure) {
+                _closeActiveDialog();
+                if (failure.message.isEmpty) return;
+                unawaited(
+                  showAppFeedbackDialog(
+                    context,
+                    title: AppStrings.feedbackErrorTitle,
+                    message: failure.message,
+                  ),
+                );
+              },
+            );
+          },
+        ),
+      ],
+      child: BlocBuilder<CardsCubit, CardsState>(
+        builder: (context, state) {
+          final cards = state.cards;
+          final isInitialLoading = state.isLoading && cards.isEmpty;
+          final hasInitialFailure = state.failure != null && cards.isEmpty;
+
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                AppStrings.cardsSectionTitle,
+                style: AppTextTheme.of(context).sectionTitle.copyWith(
+                  color: AppColorTheme.of(context).onSurface,
+                ),
+              ),
+              const SizedBox(height: 16),
+              if (isInitialLoading)
+                const Center(
+                  child: SizedBox.square(
+                    dimension: 24,
+                    child: CircularProgressIndicator.adaptive(strokeWidth: 2),
+                  ),
+                )
+              else if (hasInitialFailure)
+                _CardsRetryState(
+                  onRetryPressed: () => context.read<CardsCubit>().loadCards(),
+                )
+              else ...[
+                if (cards.isNotEmpty)
+                  Column(
+                    children: List.generate(cards.length, (index) {
+                      final card = cards[index];
+                      return Padding(
+                        padding: EdgeInsets.only(bottom: index == cards.length - 1 ? 0 : 20),
+                        child: _SavedCardDetailsWidget(
+                          card: card,
+                          onMakeDefaultPressed: () =>
+                              context.read<SetDefaultCardCubit>().setDefaultCard(card.id),
+                          onDeletePressed: () => _openDeleteDialog(card.id),
+                        ),
+                      );
+                    }),
+                  ),
+                if (cards.isNotEmpty) const SizedBox(height: 20),
+                _AddCardButton(
+                  onPressed: () => _openSaveCardDialog(cards),
+                ),
+              ],
+            ],
+          );
+        },
+      ),
+    );
+  }
+}
+
+final class _SavedCardDetailsWidget extends StatelessWidget {
+  final SavedCard card;
+  final VoidCallback onMakeDefaultPressed;
+  final VoidCallback onDeletePressed;
+
+  const _SavedCardDetailsWidget({
+    required this.card,
+    required this.onMakeDefaultPressed,
+    required this.onDeletePressed,
+  });
+
+  String _formatExpiryYear(String value) {
+    if (value.length <= 2) return value;
+    return value.substring(value.length - 2);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = AppTextTheme.of(context);
+    final colorTheme = AppColorTheme.of(context);
+    final isSetDefaultLoading = context.select<SetDefaultCardCubit, bool>(
+      (cubit) => cubit.state.maybeWhen(
+        inProgress: (pendingCardId) => pendingCardId == card.id,
+        orElse: () => false,
+      ),
+    );
+    final isDeleteLoading = context.select<DeleteCardCubit, bool>(
+      (cubit) => cubit.state.maybeWhen(
+        inProgress: (pendingCardId) => pendingCardId == card.id,
+        orElse: () => false,
+      ),
+    );
+    final isAnyDefaultInProgress = context.select<SetDefaultCardCubit, bool>(
+      (cubit) => cubit.state.maybeWhen(
+        inProgress: (_) => true,
+        orElse: () => false,
+      ),
+    );
+    final isAnyDeleteInProgress = context.select<DeleteCardCubit, bool>(
+      (cubit) => cubit.state.maybeWhen(
+        inProgress: (_) => true,
+        orElse: () => false,
+      ),
+    );
+
+    return AppCard(
+      contentPadding: const EdgeInsets.all(20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const SvgPictureWidget.icon(AppAssets.iconCardSmall),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.end,
+                      children: [
+                        Text(
+                          '**** ${card.lastFour}',
+                          style: textTheme.bodyMedium.copyWith(
+                            fontSize: 16,
+                            height: 24 / 16,
+                            fontWeight: FontWeight.w500,
+                            color: colorTheme.onSurface,
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        Text(
+                          '${card.expiryMonth}/${_formatExpiryYear(card.expiryYear)}',
+                          style: textTheme.bodyMedium.copyWith(
+                            fontSize: 16,
+                            height: 24 / 16,
+                            fontWeight: FontWeight.w400,
+                            color: colorTheme.hint,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 14),
+                    Text(
+                      card.holderName,
+                      style: textTheme.bodyMedium.copyWith(color: colorTheme.onSurface),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 24),
+          Row(
+            children: [
+              Expanded(
+                child: SecondaryButton(
+                  state: card.isDefault
+                      ? ButtonState.disabled
+                      : isSetDefaultLoading
+                      ? ButtonState.loading
+                      : isAnyDefaultInProgress || isAnyDeleteInProgress
+                      ? ButtonState.disabled
+                      : ButtonState.enabled,
+                  onPressed: onMakeDefaultPressed,
+                  child: Text(
+                    card.isDefault
+                        ? AppStrings.cardsDefaultButton
+                        : AppStrings.cardsMakeDefaultButton,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 16),
+              _DeleteCardButton(
+                isLoading: isDeleteLoading,
+                isDisabled: isAnyDeleteInProgress && !isDeleteLoading,
+                onPressed: onDeletePressed,
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+final class _DeleteCardButton extends StatelessWidget {
+  final bool isLoading;
+  final bool isDisabled;
+  final VoidCallback onPressed;
+
+  const _DeleteCardButton({
+    required this.isLoading,
+    required this.isDisabled,
+    required this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorTheme = AppColorTheme.of(context);
+
+    return IgnorePointer(
+      ignoring: isDisabled || isLoading,
+      child: Opacity(
+        opacity: isDisabled ? 0.6 : 1,
+        child: Material(
+          color: Colors.transparent,
+          child: InkWell(
+            onTap: onPressed,
+            borderRadius: BorderRadius.circular(8),
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: colorTheme.surface,
+                borderRadius: BorderRadius.circular(8),
+                border: Border.all(color: colorTheme.darkHint),
+              ),
+              child: SizedBox(
+                width: 38,
+                height: 38,
+                child: Center(
+                  child: !isLoading
+                      ? SvgPictureWidget.icon(
+                          AppAssets.iconClose,
+                          color: colorTheme.onSurface,
+                        )
+                      : const SizedBox.square(
+                          dimension: 16,
+                          child: CircularProgressIndicator.adaptive(strokeWidth: 2),
+                        ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+final class _CardsRetryState extends StatelessWidget {
+  final VoidCallback onRetryPressed;
+
+  const _CardsRetryState({
+    required this.onRetryPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorTheme = AppColorTheme.of(context);
+    final textTheme = AppTextTheme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          AppStrings.cardsLoadFailed,
+          textAlign: TextAlign.center,
+          style: textTheme.bodyMedium.copyWith(color: colorTheme.onSurface),
+        ),
+        const SizedBox(height: 16),
+        MainButton(
+          onPressed: onRetryPressed,
+          child: const Text(AppStrings.retryButton),
+        ),
+      ],
+    );
+  }
+}
+
+final class _AddCardButton extends StatefulWidget {
+  final VoidCallback onPressed;
+
+  const _AddCardButton({
+    required this.onPressed,
+  });
+
+  @override
+  State<_AddCardButton> createState() => _AddCardButtonState();
+}
+
+class _AddCardButtonState extends State<_AddCardButton> {
+  bool _isPressed = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorTheme = AppColorTheme.of(context);
+    final textTheme = AppTextTheme.of(context);
+    final foreground = _isPressed ? colorTheme.primary : colorTheme.onSurface;
+    final borderColor = _isPressed
+        ? colorTheme.primary
+        : colorTheme.outline.withValues(alpha: 0.6);
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: colorTheme.surface,
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: borderColor),
+      ),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: widget.onPressed,
+          onHighlightChanged: (value) {
+            if (!mounted) return;
+            setState(() => _isPressed = value);
+          },
+          borderRadius: BorderRadius.circular(8),
+          child: SizedBox(
+            height: 38,
+            child: Center(
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    AppStrings.cardsAddButton,
+                    style: textTheme.label.copyWith(color: foreground),
+                  ),
+                  const SizedBox(width: 2),
+                  SvgPictureWidget.icon(
+                    AppAssets.iconPlus,
+                    color: foreground,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/profile/presentation/widgets/profile_cards_section_widget.dart
+++ b/lib/features/profile/presentation/widgets/profile_cards_section_widget.dart
@@ -355,22 +355,27 @@ final class _DeleteCardButton extends StatelessWidget {
     final colorTheme = AppColorTheme.of(context);
     final isInactive = isDisabled || isLoading;
 
-    return IgnorePointer(
-      ignoring: isInactive,
-      child: InkWell(
-        onTap: onPressed,
-        borderRadius: BorderRadius.circular(8),
-        child: Container(
-          padding: const .all(10),
-          decoration: BoxDecoration(
-            color: isInactive ? colorTheme.disabled : colorTheme.surface,
-            borderRadius: BorderRadius.circular(8),
-            border: Border.all(color: colorTheme.darkHint),
-          ),
-          child: Center(
-            child: SvgPictureWidget.icon(
-              AppAssets.iconCloseVariant,
-              color: colorTheme.onSurface,
+    return Semantics(
+      button: true,
+      enabled: !isInactive,
+      label: AppStrings.cardsDeleteConfirmButton,
+      child: IgnorePointer(
+        ignoring: isInactive,
+        child: InkWell(
+          onTap: onPressed,
+          borderRadius: BorderRadius.circular(8),
+          child: Container(
+            padding: const .all(10),
+            decoration: BoxDecoration(
+              color: isInactive ? colorTheme.disabled : colorTheme.surface,
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: colorTheme.darkHint),
+            ),
+            child: Center(
+              child: SvgPictureWidget.icon(
+                AppAssets.iconCloseVariant,
+                color: colorTheme.onSurface,
+              ),
             ),
           ),
         ),

--- a/lib/features/profile/presentation/widgets/profile_cards_section_widget.dart
+++ b/lib/features/profile/presentation/widgets/profile_cards_section_widget.dart
@@ -328,7 +328,7 @@ final class _SavedCardDetailsWidget extends StatelessWidget {
               const SizedBox(width: 16),
               _DeleteCardButton(
                 isLoading: isDeleteLoading,
-                isDisabled: isAnyDeleteInProgress && !isDeleteLoading,
+                isDisabled: isAnyDefaultInProgress || (isAnyDeleteInProgress && !isDeleteLoading),
                 onPressed: onDeletePressed,
               ),
             ],

--- a/lib/features/profile/presentation/widgets/profile_cards_section_widget.dart
+++ b/lib/features/profile/presentation/widgets/profile_cards_section_widget.dart
@@ -353,37 +353,24 @@ final class _DeleteCardButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorTheme = AppColorTheme.of(context);
+    final isInactive = isDisabled || isLoading;
 
     return IgnorePointer(
-      ignoring: isDisabled || isLoading,
-      child: Opacity(
-        opacity: isDisabled ? 0.6 : 1,
-        child: Material(
-          color: Colors.transparent,
-          child: InkWell(
-            onTap: onPressed,
+      ignoring: isInactive,
+      child: InkWell(
+        onTap: onPressed,
+        borderRadius: BorderRadius.circular(8),
+        child: Container(
+          padding: const .all(10),
+          decoration: BoxDecoration(
+            color: isInactive ? colorTheme.disabled : colorTheme.surface,
             borderRadius: BorderRadius.circular(8),
-            child: DecoratedBox(
-              decoration: BoxDecoration(
-                color: colorTheme.surface,
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(color: colorTheme.darkHint),
-              ),
-              child: SizedBox(
-                width: 38,
-                height: 38,
-                child: Center(
-                  child: !isLoading
-                      ? SvgPictureWidget.icon(
-                          AppAssets.iconClose,
-                          color: colorTheme.onSurface,
-                        )
-                      : const SizedBox.square(
-                          dimension: 16,
-                          child: CircularProgressIndicator.adaptive(strokeWidth: 2),
-                        ),
-                ),
-              ),
+            border: Border.all(color: colorTheme.darkHint),
+          ),
+          child: Center(
+            child: SvgPictureWidget.icon(
+              AppAssets.iconCloseVariant,
+              color: colorTheme.onSurface,
             ),
           ),
         ),
@@ -441,9 +428,7 @@ class _AddCardButtonState extends State<_AddCardButton> {
     final colorTheme = AppColorTheme.of(context);
     final textTheme = AppTextTheme.of(context);
     final foreground = _isPressed ? colorTheme.primary : colorTheme.onSurface;
-    final borderColor = _isPressed
-        ? colorTheme.primary
-        : colorTheme.outline.withValues(alpha: 0.6);
+    final borderColor = _isPressed ? colorTheme.primary : colorTheme.outline.withValues(alpha: 0.6);
 
     return DecoratedBox(
       decoration: BoxDecoration(
@@ -451,32 +436,29 @@ class _AddCardButtonState extends State<_AddCardButton> {
         borderRadius: BorderRadius.circular(8),
         border: Border.all(color: borderColor),
       ),
-      child: Material(
-        color: Colors.transparent,
-        child: InkWell(
-          onTap: widget.onPressed,
-          onHighlightChanged: (value) {
-            if (!mounted) return;
-            setState(() => _isPressed = value);
-          },
-          borderRadius: BorderRadius.circular(8),
-          child: SizedBox(
-            height: 38,
-            child: Center(
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    AppStrings.cardsAddButton,
-                    style: textTheme.label.copyWith(color: foreground),
-                  ),
-                  const SizedBox(width: 2),
-                  SvgPictureWidget.icon(
-                    AppAssets.iconPlus,
-                    color: foreground,
-                  ),
-                ],
-              ),
+      child: InkWell(
+        onTap: widget.onPressed,
+        onHighlightChanged: (value) {
+          if (!mounted) return;
+          setState(() => _isPressed = value);
+        },
+        borderRadius: BorderRadius.circular(8),
+        child: SizedBox(
+          height: 38,
+          child: Center(
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  AppStrings.cardsAddButton,
+                  style: textTheme.label.copyWith(color: foreground),
+                ),
+                const SizedBox(width: 2),
+                SvgPictureWidget.icon(
+                  AppAssets.iconPlus,
+                  color: foreground,
+                ),
+              ],
             ),
           ),
         ),

--- a/test/features/cards/data/repositories/cards_repository_impl_test.dart
+++ b/test/features/cards/data/repositories/cards_repository_impl_test.dart
@@ -1,0 +1,270 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:moveup_flutter/core/failures/feature/cards/cards_failure.dart';
+import 'package:moveup_flutter/core/utils/logger/app_logger.dart';
+import 'package:moveup_flutter/features/cards/data/dto/save_card_request_dto.dart';
+import 'package:moveup_flutter/features/cards/data/remote/cards_api_client.dart';
+import 'package:moveup_flutter/features/cards/data/repositories/cards_repository_impl.dart';
+import 'package:moveup_flutter/features/cards/domain/repositories/cards_repository.dart';
+
+import '../../support/cards_dto_fixtures.dart';
+import 'cards_repository_impl_test.mocks.dart';
+
+@GenerateNiceMocks([
+  MockSpec<AppLogger>(),
+  MockSpec<CardsApiClient>(),
+])
+void main() {
+  late MockAppLogger logger;
+  late MockCardsApiClient apiClient;
+  late CardsRepository repository;
+
+  setUp(() {
+    logger = MockAppLogger();
+    apiClient = MockCardsApiClient();
+    repository = CardsRepositoryImpl(logger, apiClient);
+  });
+
+  group('CardsRepositoryImpl', () {
+    group('CardsRepositoryImpl.getCards', () {
+      test('returns success(cards) when api succeeds', () async {
+        final responseDto = createSavedCardsResponseDto();
+        final expectedCards = createSavedCards();
+        when(apiClient.getCards()).thenAnswer((_) async => responseDto);
+
+        final result = await repository.getCards();
+
+        expect(result.isSuccess, isTrue);
+        expect(result.success, expectedCards);
+        expect(result.success!.first.isDefault, isTrue);
+
+        verify(apiClient.getCards()).called(1);
+        verifyNever(logger.e(any, any, any));
+        verifyNoMoreInteractions(apiClient);
+      });
+
+      test('keeps default card first in returned cards list', () async {
+        final responseDto = createSavedCardsResponseDto();
+        when(apiClient.getCards()).thenAnswer((_) async => responseDto);
+
+        final result = await repository.getCards();
+
+        expect(result.isSuccess, isTrue);
+        expect(result.success!.map((card) => card.id), [1, 2]);
+
+        verify(apiClient.getCards()).called(1);
+        verifyNever(logger.e(any, any, any));
+        verifyNoMoreInteractions(apiClient);
+      });
+
+      test('returns CardsRequestFailure when api returns server error', () async {
+        final exception = createCardsDioBadResponseException(
+          path: '/payment/cards',
+          statusCode: 500,
+        );
+        when(apiClient.getCards()).thenThrow(exception);
+
+        final result = await repository.getCards();
+
+        expect(result.isFailure, isTrue);
+        expect(result.failure, isA<CardsRequestFailure>());
+        expect(result.failure!.parentException, exception);
+
+        verify(apiClient.getCards()).called(1);
+        verifyNever(logger.e(any, any, any));
+        verifyNoMoreInteractions(apiClient);
+      });
+
+      test('returns UnknownCardsFailure when unexpected exception occurs', () async {
+        final exception = Exception('unexpected_error');
+        when(apiClient.getCards()).thenThrow(exception);
+
+        final result = await repository.getCards();
+
+        expect(result.isFailure, isTrue);
+        expect(result.failure, isA<UnknownCardsFailure>());
+        expect(result.failure!.parentException, exception);
+
+        verify(apiClient.getCards()).called(1);
+        verify(logger.e(any, exception, any)).called(1);
+        verifyNoMoreInteractions(apiClient);
+      });
+    });
+
+    group('CardsRepositoryImpl.saveCard', () {
+      test('returns success when save api succeeds', () async {
+        when(apiClient.saveCard(any)).thenAnswer((_) async {});
+
+        final result = await repository.saveCard(payload: testSaveCardPayload);
+
+        expect(result.isSuccess, isTrue);
+        verify(
+          apiClient.saveCard(
+            argThat(
+              isA<SaveCardRequestDto>()
+                  .having((request) => request.cardNumber, 'cardNumber', '4111111111111111')
+                  .having((request) => request.cardHolder, 'cardHolder', 'IVAN IVANOV')
+                  .having((request) => request.expiryMonth, 'expiryMonth', '12')
+                  .having((request) => request.expiryYear, 'expiryYear', '2029'),
+            ),
+          ),
+        ).called(1);
+        verifyNever(logger.e(any, any, any));
+        verifyNoMoreInteractions(apiClient);
+      });
+
+      test('returns CardsValidationFailure on validation error', () async {
+        final exception = createCardsDioBadResponseException(
+          path: '/payment/cards/save',
+          statusCode: 422,
+          code: 'validation_failed',
+          message: 'validation_failed',
+          errors: {
+            'card_number': ['Введите корректный номер карты'],
+            'card_holder': ['Введите имя держателя'],
+          },
+        );
+        when(apiClient.saveCard(any)).thenThrow(exception);
+
+        final result = await repository.saveCard(payload: testSaveCardPayload);
+
+        expect(result.isFailure, isTrue);
+        expect(result.failure, isA<CardsValidationFailure>());
+        expect(
+          result.failure!.message,
+          'Введите корректный номер карты\nВведите имя держателя',
+        );
+
+        verify(apiClient.saveCard(any)).called(1);
+        verifyNever(logger.e(any, any, any));
+        verifyNoMoreInteractions(apiClient);
+      });
+
+      test('returns CardsRequestFailure when save api returns server error', () async {
+        final exception = createCardsDioBadResponseException(
+          path: '/payment/cards/save',
+          statusCode: 500,
+        );
+        when(apiClient.saveCard(any)).thenThrow(exception);
+
+        final result = await repository.saveCard(payload: testSaveCardPayload);
+
+        expect(result.isFailure, isTrue);
+        expect(result.failure, isA<CardsRequestFailure>());
+        expect(result.failure!.parentException, exception);
+
+        verify(apiClient.saveCard(any)).called(1);
+        verifyNever(logger.e(any, any, any));
+        verifyNoMoreInteractions(apiClient);
+      });
+
+      test('returns UnknownCardsFailure when save throws unexpected exception', () async {
+        final exception = Exception('unexpected_save_error');
+        when(apiClient.saveCard(any)).thenThrow(exception);
+
+        final result = await repository.saveCard(payload: testSaveCardPayload);
+
+        expect(result.isFailure, isTrue);
+        expect(result.failure, isA<UnknownCardsFailure>());
+        expect(result.failure!.parentException, exception);
+
+        verify(apiClient.saveCard(any)).called(1);
+        verify(logger.e(any, exception, any)).called(1);
+        verifyNoMoreInteractions(apiClient);
+      });
+    });
+
+    group('CardsRepositoryImpl.setDefaultCard', () {
+      test('returns success when default api succeeds', () async {
+        when(apiClient.setDefaultCard(2)).thenAnswer((_) async {});
+
+        final result = await repository.setDefaultCard(2);
+
+        expect(result.isSuccess, isTrue);
+        verify(apiClient.setDefaultCard(2)).called(1);
+        verifyNever(logger.e(any, any, any));
+        verifyNoMoreInteractions(apiClient);
+      });
+
+      test('returns CardsRequestFailure when default api returns server error', () async {
+        final exception = createCardsDioBadResponseException(
+          path: '/payment/cards/2/default',
+          statusCode: 500,
+        );
+        when(apiClient.setDefaultCard(2)).thenThrow(exception);
+
+        final result = await repository.setDefaultCard(2);
+
+        expect(result.isFailure, isTrue);
+        expect(result.failure, isA<CardsRequestFailure>());
+        expect(result.failure!.parentException, exception);
+
+        verify(apiClient.setDefaultCard(2)).called(1);
+        verifyNever(logger.e(any, any, any));
+        verifyNoMoreInteractions(apiClient);
+      });
+
+      test('returns UnknownCardsFailure when default throws unexpected exception', () async {
+        final exception = Exception('unexpected_default_error');
+        when(apiClient.setDefaultCard(2)).thenThrow(exception);
+
+        final result = await repository.setDefaultCard(2);
+
+        expect(result.isFailure, isTrue);
+        expect(result.failure, isA<UnknownCardsFailure>());
+        expect(result.failure!.parentException, exception);
+
+        verify(apiClient.setDefaultCard(2)).called(1);
+        verify(logger.e(any, exception, any)).called(1);
+        verifyNoMoreInteractions(apiClient);
+      });
+    });
+
+    group('CardsRepositoryImpl.deleteCard', () {
+      test('returns success when delete api succeeds', () async {
+        when(apiClient.deleteCard(2)).thenAnswer((_) async {});
+
+        final result = await repository.deleteCard(2);
+
+        expect(result.isSuccess, isTrue);
+        verify(apiClient.deleteCard(2)).called(1);
+        verifyNever(logger.e(any, any, any));
+        verifyNoMoreInteractions(apiClient);
+      });
+
+      test('returns CardsRequestFailure when delete api returns server error', () async {
+        final exception = createCardsDioBadResponseException(
+          path: '/payment/cards/2',
+          statusCode: 500,
+        );
+        when(apiClient.deleteCard(2)).thenThrow(exception);
+
+        final result = await repository.deleteCard(2);
+
+        expect(result.isFailure, isTrue);
+        expect(result.failure, isA<CardsRequestFailure>());
+        expect(result.failure!.parentException, exception);
+
+        verify(apiClient.deleteCard(2)).called(1);
+        verifyNever(logger.e(any, any, any));
+        verifyNoMoreInteractions(apiClient);
+      });
+
+      test('returns UnknownCardsFailure when delete throws unexpected exception', () async {
+        final exception = Exception('unexpected_delete_error');
+        when(apiClient.deleteCard(2)).thenThrow(exception);
+
+        final result = await repository.deleteCard(2);
+
+        expect(result.isFailure, isTrue);
+        expect(result.failure, isA<UnknownCardsFailure>());
+        expect(result.failure!.parentException, exception);
+
+        verify(apiClient.deleteCard(2)).called(1);
+        verify(logger.e(any, exception, any)).called(1);
+        verifyNoMoreInteractions(apiClient);
+      });
+    });
+  });
+}

--- a/test/features/cards/presentation/cubits/cards_cubit_test.dart
+++ b/test/features/cards/presentation/cubits/cards_cubit_test.dart
@@ -1,0 +1,93 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:moveup_flutter/core/failures/feature/cards/cards_failure.dart';
+import 'package:moveup_flutter/core/result/result.dart';
+import 'package:moveup_flutter/features/cards/domain/entities/saved_card.dart';
+import 'package:moveup_flutter/features/cards/domain/repositories/cards_repository.dart';
+import 'package:moveup_flutter/features/cards/presentation/cubits/cards_cubit.dart';
+
+import '../../support/cards_dto_fixtures.dart';
+import 'cards_cubit_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<CardsRepository>()])
+void main() {
+  late MockCardsRepository repository;
+  late CardsCubit cubit;
+
+  setUp(() {
+    repository = MockCardsRepository();
+    cubit = CardsCubit(repository);
+    provideDummy<Result<List<SavedCard>, CardsFailure>>(
+      Success<List<SavedCard>, CardsFailure>(createSavedCards()),
+    );
+  });
+
+  group('CardsCubit', () {
+    blocTest<CardsCubit, CardsState>(
+      'loads cards when request succeeds',
+      setUp: () => when(repository.getCards()).thenAnswer(
+        (_) async => Success<List<SavedCard>, CardsFailure>(createSavedCards()),
+      ),
+      build: () => cubit,
+      act: (cubit) => cubit.loadCards(),
+      expect: () => [
+        const CardsState(isLoading: true),
+        CardsState(cards: createSavedCards()),
+      ],
+      verify: (_) => verify(repository.getCards()).called(1),
+    );
+
+    blocTest<CardsCubit, CardsState>(
+      'emits failed state when request fails',
+      setUp: () => when(repository.getCards()).thenAnswer(
+        (_) async => const Failure<List<SavedCard>, CardsFailure>(
+          CardsRequestFailure('error_message'),
+        ),
+      ),
+      build: () => cubit,
+      act: (cubit) => cubit.loadCards(),
+      expect: () => const [
+        CardsState(isLoading: true),
+        CardsState(failure: CardsRequestFailure('error_message')),
+      ],
+      verify: (_) => verify(repository.getCards()).called(1),
+    );
+
+    blocTest<CardsCubit, CardsState>(
+      'emits loading only once when loadCards is called twice',
+      setUp: () => when(repository.getCards()).thenAnswer(
+        (_) async => Success<List<SavedCard>, CardsFailure>(createSavedCards()),
+      ),
+      build: () => cubit,
+      act: (cubit) {
+        cubit.loadCards();
+        cubit.loadCards();
+      },
+      expect: () => [
+        const CardsState(isLoading: true),
+        CardsState(cards: createSavedCards()),
+      ],
+      verify: (_) => verify(repository.getCards()).called(1),
+    );
+
+    blocTest<CardsCubit, CardsState>(
+      'keeps previous cards while refresh is in progress',
+      setUp: () => when(repository.getCards()).thenAnswer(
+        (_) async => Success<List<SavedCard>, CardsFailure>(createSavedCards()),
+      ),
+      build: () => cubit,
+      seed: () => CardsState(cards: createSavedCards()),
+      act: (cubit) => cubit.loadCards(),
+      expect: () => [
+        CardsState(
+          isLoading: true,
+          cards: createSavedCards(),
+        ),
+        CardsState(cards: createSavedCards()),
+      ],
+      verify: (_) => verify(repository.getCards()).called(1),
+    );
+  });
+}

--- a/test/features/cards/presentation/cubits/delete_card_cubit_test.dart
+++ b/test/features/cards/presentation/cubits/delete_card_cubit_test.dart
@@ -1,0 +1,73 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:moveup_flutter/core/failures/feature/cards/cards_failure.dart';
+import 'package:moveup_flutter/core/result/result.dart';
+import 'package:moveup_flutter/features/cards/domain/repositories/cards_repository.dart';
+import 'package:moveup_flutter/features/cards/presentation/cubits/delete_card_cubit.dart';
+
+import 'delete_card_cubit_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<CardsRepository>()])
+void main() {
+  late MockCardsRepository repository;
+  late DeleteCardCubit cubit;
+
+  setUp(() {
+    repository = MockCardsRepository();
+    cubit = DeleteCardCubit(repository);
+    provideDummy<Result<void, CardsFailure>>(
+      const Success<void, CardsFailure>(null),
+    );
+  });
+
+  group('DeleteCardCubit', () {
+    const cardsFailure = CardsRequestFailure('error_message');
+
+    blocTest<DeleteCardCubit, DeleteCardState>(
+      'emits succeed when delete succeeds',
+      setUp: () => when(
+        repository.deleteCard(2),
+      ).thenAnswer((_) async => const Success<void, CardsFailure>(null)),
+      build: () => cubit,
+      act: (cubit) => cubit.deleteCard(2),
+      expect: () => const [
+        DeleteCardState.inProgress(2),
+        DeleteCardState.succeed(),
+      ],
+      verify: (_) => verify(repository.deleteCard(2)).called(1),
+    );
+
+    blocTest<DeleteCardCubit, DeleteCardState>(
+      'emits failed when delete fails',
+      setUp: () => when(
+        repository.deleteCard(2),
+      ).thenAnswer((_) async => const Failure<void, CardsFailure>(cardsFailure)),
+      build: () => cubit,
+      act: (cubit) => cubit.deleteCard(2),
+      expect: () => const [
+        DeleteCardState.inProgress(2),
+        DeleteCardState.failed(cardsFailure),
+      ],
+      verify: (_) => verify(repository.deleteCard(2)).called(1),
+    );
+
+    blocTest<DeleteCardCubit, DeleteCardState>(
+      'emits inProgress only once when deleteCard is called twice',
+      setUp: () => when(
+        repository.deleteCard(2),
+      ).thenAnswer((_) async => const Success<void, CardsFailure>(null)),
+      build: () => cubit,
+      act: (cubit) {
+        cubit.deleteCard(2);
+        cubit.deleteCard(2);
+      },
+      expect: () => const [
+        DeleteCardState.inProgress(2),
+        DeleteCardState.succeed(),
+      ],
+      verify: (_) => verify(repository.deleteCard(2)).called(1),
+    );
+  });
+}

--- a/test/features/cards/presentation/cubits/save_card_cubit_test.dart
+++ b/test/features/cards/presentation/cubits/save_card_cubit_test.dart
@@ -1,0 +1,74 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:moveup_flutter/core/failures/feature/cards/cards_failure.dart';
+import 'package:moveup_flutter/core/result/result.dart';
+import 'package:moveup_flutter/features/cards/domain/repositories/cards_repository.dart';
+import 'package:moveup_flutter/features/cards/presentation/cubits/save_card_cubit.dart';
+
+import '../../support/cards_dto_fixtures.dart';
+import 'save_card_cubit_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<CardsRepository>()])
+void main() {
+  late MockCardsRepository repository;
+  late SaveCardCubit cubit;
+
+  setUp(() {
+    repository = MockCardsRepository();
+    cubit = SaveCardCubit(repository);
+    provideDummy<Result<void, CardsFailure>>(
+      const Success<void, CardsFailure>(null),
+    );
+  });
+
+  group('SaveCardCubit', () {
+    const cardsFailure = CardsRequestFailure('error_message');
+
+    blocTest<SaveCardCubit, SaveCardState>(
+      'emits succeed when save succeeds',
+      setUp: () => when(
+        repository.saveCard(payload: testSaveCardPayload),
+      ).thenAnswer((_) async => const Success<void, CardsFailure>(null)),
+      build: () => cubit,
+      act: (cubit) => cubit.saveCard(payload: testSaveCardPayload),
+      expect: () => const [
+        SaveCardState.inProgress(),
+        SaveCardState.succeed(),
+      ],
+      verify: (_) => verify(repository.saveCard(payload: testSaveCardPayload)).called(1),
+    );
+
+    blocTest<SaveCardCubit, SaveCardState>(
+      'emits failed when save fails',
+      setUp: () => when(
+        repository.saveCard(payload: testSaveCardPayload),
+      ).thenAnswer((_) async => const Failure<void, CardsFailure>(cardsFailure)),
+      build: () => cubit,
+      act: (cubit) => cubit.saveCard(payload: testSaveCardPayload),
+      expect: () => const [
+        SaveCardState.inProgress(),
+        SaveCardState.failed(cardsFailure),
+      ],
+      verify: (_) => verify(repository.saveCard(payload: testSaveCardPayload)).called(1),
+    );
+
+    blocTest<SaveCardCubit, SaveCardState>(
+      'emits inProgress only once when saveCard is called twice',
+      setUp: () => when(
+        repository.saveCard(payload: testSaveCardPayload),
+      ).thenAnswer((_) async => const Success<void, CardsFailure>(null)),
+      build: () => cubit,
+      act: (cubit) {
+        cubit.saveCard(payload: testSaveCardPayload);
+        cubit.saveCard(payload: testSaveCardPayload);
+      },
+      expect: () => const [
+        SaveCardState.inProgress(),
+        SaveCardState.succeed(),
+      ],
+      verify: (_) => verify(repository.saveCard(payload: testSaveCardPayload)).called(1),
+    );
+  });
+}

--- a/test/features/cards/presentation/cubits/set_default_card_cubit_test.dart
+++ b/test/features/cards/presentation/cubits/set_default_card_cubit_test.dart
@@ -1,0 +1,73 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:moveup_flutter/core/failures/feature/cards/cards_failure.dart';
+import 'package:moveup_flutter/core/result/result.dart';
+import 'package:moveup_flutter/features/cards/domain/repositories/cards_repository.dart';
+import 'package:moveup_flutter/features/cards/presentation/cubits/set_default_card_cubit.dart';
+
+import 'set_default_card_cubit_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<CardsRepository>()])
+void main() {
+  late MockCardsRepository repository;
+  late SetDefaultCardCubit cubit;
+
+  setUp(() {
+    repository = MockCardsRepository();
+    cubit = SetDefaultCardCubit(repository);
+    provideDummy<Result<void, CardsFailure>>(
+      const Success<void, CardsFailure>(null),
+    );
+  });
+
+  group('SetDefaultCardCubit', () {
+    const cardsFailure = CardsRequestFailure('error_message');
+
+    blocTest<SetDefaultCardCubit, SetDefaultCardState>(
+      'emits succeed when setDefault succeeds',
+      setUp: () => when(repository.setDefaultCard(2)).thenAnswer(
+        (_) async => const Success<void, CardsFailure>(null),
+      ),
+      build: () => cubit,
+      act: (cubit) => cubit.setDefaultCard(2),
+      expect: () => const [
+        SetDefaultCardState.inProgress(2),
+        SetDefaultCardState.succeed(),
+      ],
+      verify: (_) => verify(repository.setDefaultCard(2)).called(1),
+    );
+
+    blocTest<SetDefaultCardCubit, SetDefaultCardState>(
+      'emits failed when setDefault fails',
+      setUp: () => when(
+        repository.setDefaultCard(2),
+      ).thenAnswer((_) async => const Failure<void, CardsFailure>(cardsFailure)),
+      build: () => cubit,
+      act: (cubit) => cubit.setDefaultCard(2),
+      expect: () => const [
+        SetDefaultCardState.inProgress(2),
+        SetDefaultCardState.failed(cardsFailure),
+      ],
+      verify: (_) => verify(repository.setDefaultCard(2)).called(1),
+    );
+
+    blocTest<SetDefaultCardCubit, SetDefaultCardState>(
+      'emits inProgress only once when setDefaultCard is called twice',
+      setUp: () => when(repository.setDefaultCard(2)).thenAnswer(
+        (_) async => const Success<void, CardsFailure>(null),
+      ),
+      build: () => cubit,
+      act: (cubit) {
+        cubit.setDefaultCard(2);
+        cubit.setDefaultCard(2);
+      },
+      expect: () => const [
+        SetDefaultCardState.inProgress(2),
+        SetDefaultCardState.succeed(),
+      ],
+      verify: (_) => verify(repository.setDefaultCard(2)).called(1),
+    );
+  });
+}

--- a/test/features/cards/presentation/validators/card_form_validators_test.dart
+++ b/test/features/cards/presentation/validators/card_form_validators_test.dart
@@ -34,8 +34,7 @@ void main() {
       expect(CardFormValidators.cardHolder('   '), requiredMessage);
     });
 
-    test('returns invalid error when value contains non-uppercase latin symbols', () {
-      expect(CardFormValidators.cardHolder('Ivan Ivanov'), invalidMessage);
+    test('returns invalid error when value contains non-latin or non-letter symbols', () {
       expect(CardFormValidators.cardHolder('ИВАН ИВАНОВ'), invalidMessage);
       expect(CardFormValidators.cardHolder('IVAN1 IVANOV'), invalidMessage);
       expect(CardFormValidators.cardHolder('IVAN- IVANOV'), invalidMessage);
@@ -43,6 +42,7 @@ void main() {
 
     test('returns null when value is valid', () {
       expect(CardFormValidators.cardHolder('IVAN IVANOV'), isNull);
+      expect(CardFormValidators.cardHolder('Ivan Ivanov'), isNull);
       expect(CardFormValidators.cardHolder('  IVAN IVANOV  '), isNull);
       expect(CardFormValidators.cardHolder('IVAN'), isNull);
     });

--- a/test/features/cards/presentation/validators/card_form_validators_test.dart
+++ b/test/features/cards/presentation/validators/card_form_validators_test.dart
@@ -1,0 +1,211 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:moveup_flutter/features/cards/presentation/validators/card_form_validators.dart';
+
+void main() {
+  group('CardFormValidators.cardNumber', () {
+    const requiredMessage = 'Введите номер карты';
+    const invalidMessage = 'Номер карты должен состоять из 16 цифр';
+
+    test('returns required error when value is empty', () {
+      expect(CardFormValidators.cardNumber(null), requiredMessage);
+      expect(CardFormValidators.cardNumber(''), requiredMessage);
+      expect(CardFormValidators.cardNumber('   '), requiredMessage);
+    });
+
+    test('returns invalid error when card number length is not 16 digits', () {
+      expect(CardFormValidators.cardNumber('1234'), invalidMessage);
+      expect(CardFormValidators.cardNumber('1234 5678 9012 345'), invalidMessage);
+      expect(CardFormValidators.cardNumber('1234 5678 9012 34567'), invalidMessage);
+    });
+
+    test('returns null when card number contains exactly 16 digits', () {
+      expect(CardFormValidators.cardNumber('1234 5678 9012 3456'), isNull);
+    });
+  });
+
+  group('CardFormValidators.cardHolder', () {
+    const requiredMessage = 'Введите имя держателя карты';
+    const invalidMessage =
+        'Имя держателя карты должно содержать только заглавные латинские буквы и пробелы';
+
+    test('returns required error when value is empty', () {
+      expect(CardFormValidators.cardHolder(null), requiredMessage);
+      expect(CardFormValidators.cardHolder(''), requiredMessage);
+      expect(CardFormValidators.cardHolder('   '), requiredMessage);
+    });
+
+    test('returns invalid error when value contains non-uppercase latin symbols', () {
+      expect(CardFormValidators.cardHolder('Ivan Ivanov'), invalidMessage);
+      expect(CardFormValidators.cardHolder('ИВАН ИВАНОВ'), invalidMessage);
+      expect(CardFormValidators.cardHolder('IVAN1 IVANOV'), invalidMessage);
+      expect(CardFormValidators.cardHolder('IVAN- IVANOV'), invalidMessage);
+    });
+
+    test('returns null when value is valid', () {
+      expect(CardFormValidators.cardHolder('IVAN IVANOV'), isNull);
+      expect(CardFormValidators.cardHolder('  IVAN IVANOV  '), isNull);
+      expect(CardFormValidators.cardHolder('IVAN'), isNull);
+    });
+  });
+
+  group('CardFormValidators.expiryMonth', () {
+    const invalidMessage = 'Месяц';
+    final fixedNow = DateTime(2026, 4, 2);
+
+    test('returns invalid error when value is empty', () {
+      expect(CardFormValidators.expiryMonth(null), invalidMessage);
+      expect(CardFormValidators.expiryMonth(''), invalidMessage);
+      expect(CardFormValidators.expiryMonth('   '), invalidMessage);
+    });
+
+    test('returns invalid error when month is out of range', () {
+      expect(CardFormValidators.expiryMonth('0'), invalidMessage);
+      expect(CardFormValidators.expiryMonth('13'), invalidMessage);
+      expect(CardFormValidators.expiryMonth('99'), invalidMessage);
+    });
+
+    test('returns null when month is in range', () {
+      expect(CardFormValidators.expiryMonth('1'), isNull);
+      expect(CardFormValidators.expiryMonth('12'), isNull);
+    });
+
+    test('returns hidden error when month is earlier than current month in current year', () {
+      expect(
+        CardFormValidators.expiryMonth(
+          '3',
+          yearValue: '2026',
+          now: fixedNow,
+        ),
+        isNotNull,
+      );
+    });
+
+    test('returns null when month is current or future in current year', () {
+      expect(
+        CardFormValidators.expiryMonth(
+          '4',
+          yearValue: '2026',
+          now: fixedNow,
+        ),
+        isNull,
+      );
+      expect(
+        CardFormValidators.expiryMonth(
+          '5',
+          yearValue: '2026',
+          now: fixedNow,
+        ),
+        isNull,
+      );
+    });
+
+    test('returns hidden error when year is unrealistically far in the future', () {
+      expect(
+        CardFormValidators.expiryMonth(
+          '5',
+          yearValue: '9999',
+          now: fixedNow,
+        ),
+        isNotNull,
+      );
+    });
+  });
+
+  group('CardFormValidators.expiryYear', () {
+    const invalidMessage = 'Год';
+    final fixedNow = DateTime(2026, 4, 2);
+
+    test('returns invalid error when value is empty', () {
+      expect(CardFormValidators.expiryYear(null), invalidMessage);
+      expect(CardFormValidators.expiryYear(''), invalidMessage);
+      expect(CardFormValidators.expiryYear('   '), invalidMessage);
+    });
+
+    test('returns invalid error when year length is not 4', () {
+      expect(CardFormValidators.expiryYear('24'), invalidMessage);
+      expect(CardFormValidators.expiryYear('202'), invalidMessage);
+      expect(CardFormValidators.expiryYear('20245'), invalidMessage);
+    });
+
+    test('returns null when year length is 4', () {
+      expect(CardFormValidators.expiryYear('2026'), isNull);
+      expect(CardFormValidators.expiryYear(' 2026 '), isNull);
+    });
+
+    test('returns hidden error when year is before current year', () {
+      expect(
+        CardFormValidators.expiryYear(
+          '2025',
+          now: fixedNow,
+        ),
+        isNotNull,
+      );
+    });
+
+    test('returns hidden error when month is already in the past for current year', () {
+      expect(
+        CardFormValidators.expiryYear(
+          '2026',
+          monthValue: '3',
+          now: fixedNow,
+        ),
+        isNotNull,
+      );
+    });
+
+    test('returns null when current year is paired with current or future month', () {
+      expect(
+        CardFormValidators.expiryYear(
+          '2026',
+          monthValue: '4',
+          now: fixedNow,
+        ),
+        isNull,
+      );
+      expect(
+        CardFormValidators.expiryYear(
+          '2026',
+          monthValue: '12',
+          now: fixedNow,
+        ),
+        isNull,
+      );
+    });
+
+    test('returns hidden error when year is unrealistically far in the future', () {
+      expect(
+        CardFormValidators.expiryYear(
+          '9999',
+          now: fixedNow,
+        ),
+        isNotNull,
+      );
+    });
+  });
+
+  group('CardFormValidators.cvv', () {
+    const invalidMessage = '***';
+
+    test('returns invalid error when value is empty', () {
+      expect(CardFormValidators.cvv(null), invalidMessage);
+      expect(CardFormValidators.cvv(''), invalidMessage);
+      expect(CardFormValidators.cvv('   '), invalidMessage);
+    });
+
+    test('returns invalid error when cvv length is not 3', () {
+      expect(CardFormValidators.cvv('1'), invalidMessage);
+      expect(CardFormValidators.cvv('12'), invalidMessage);
+      expect(CardFormValidators.cvv('1234'), invalidMessage);
+    });
+
+    test('returns invalid error when cvv contains non-digit characters', () {
+      expect(CardFormValidators.cvv('abc'), invalidMessage);
+      expect(CardFormValidators.cvv('12a'), invalidMessage);
+    });
+
+    test('returns null when cvv length is 3', () {
+      expect(CardFormValidators.cvv('123'), isNull);
+      expect(CardFormValidators.cvv(' 123 '), isNull);
+    });
+  });
+}

--- a/test/features/cards/support/cards_dto_fixtures.dart
+++ b/test/features/cards/support/cards_dto_fixtures.dart
@@ -1,0 +1,80 @@
+import 'package:dio/dio.dart';
+import 'package:moveup_flutter/features/cards/data/dto/saved_card_dto.dart';
+import 'package:moveup_flutter/features/cards/data/dto/saved_cards_response_dto.dart';
+import 'package:moveup_flutter/features/cards/domain/entities/save_card_payload.dart';
+import 'package:moveup_flutter/features/cards/domain/entities/saved_card.dart';
+
+/// Test fixture for cards response DTO.
+SavedCardsResponseDto createSavedCardsResponseDto() => SavedCardsResponseDto(
+  data: [
+    SavedCardDto(
+      id: 1,
+      cardHolder: 'IVAN IVANOV',
+      cardLastFour: '4585',
+      expiryMonth: '01',
+      expiryYear: '2054',
+      isDefault: true,
+    ),
+    SavedCardDto(
+      id: 2,
+      cardHolder: 'IVAN IVANOV',
+      cardLastFour: '7585',
+      expiryMonth: '01',
+      expiryYear: '2044',
+      isDefault: false,
+    ),
+  ],
+);
+
+/// Test fixture for cards domain entities.
+List<SavedCard> createSavedCards() => const [
+  SavedCard(
+    id: 1,
+    holderName: 'IVAN IVANOV',
+    lastFour: '4585',
+    expiryMonth: '01',
+    expiryYear: '2054',
+    isDefault: true,
+  ),
+  SavedCard(
+    id: 2,
+    holderName: 'IVAN IVANOV',
+    lastFour: '7585',
+    expiryMonth: '01',
+    expiryYear: '2044',
+    isDefault: false,
+  ),
+];
+
+/// Test fixture for saving a new card.
+const testSaveCardPayload = SaveCardPayload(
+  cardNumber: '4111111111111111',
+  cardHolder: 'IVAN IVANOV',
+  expiryMonth: '12',
+  expiryYear: '2029',
+);
+
+/// Creates a bad-response [DioException] for cards API tests.
+DioException createCardsDioBadResponseException({
+  required String path,
+  required int statusCode,
+  String code = 'server_error',
+  String message = 'error',
+  Map<String, List<String>>? errors,
+}) {
+  final requestOptions = RequestOptions(path: path);
+  return DioException(
+    requestOptions: requestOptions,
+    response: Response<Map<String, dynamic>>(
+      requestOptions: requestOptions,
+      statusCode: statusCode,
+      data: {
+        'success': false,
+        'message': message,
+        'code': code,
+        'errors': ?errors,
+      },
+    ),
+    type: DioExceptionType.badResponse,
+  );
+}


### PR DESCRIPTION
## 🚀 Summary

Implemented the full profile cards section vertical slice for the authenticated `/profile` tab end-to-end (API contract → repository → cubit → UI).

## 🧪 Verification

- [x] `flutter analyze`
- [x] `flutter test test/features/cards`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Profile page: saved payment cards section (up to 3 cards).
  * Add card dialog with real-time preview, input validation, and CVV entry.
  * Set a default card and delete cards with confirmation dialogs.
  * Local refresh of the profile cards list after successful add/default/delete actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->