### PR TITLE
fix(auth): redirect unverified users to email verification screen after sign-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Profile frequency statistics now handle weekly payloads without `short_label`, keep dense period charts readable across `week`, `month`, `3 months`, `6 months`, and `year`, and clarify non-daily X-axis scales with short `нед.` / `мес.` labels.
 - Profile statistics dropdown menus now size to their content and render above surrounding UI instead of being clipped by the statistics card or overlapping incorrectly with lower screen sections.
 - Profile history and statistics copy now matches the latest profile mockups more closely, including `Активность` / `Завершено` labels, the separate `Средняя оценка:` summary label, and shortened cross-year period labels like `25-26`.
+- Sign-up unverified-email redirect now correctly closes the feedback dialog before pushing the verify-email route, and cancels the redirect timer when the widget is disposed.
 
 ## [0.3.1] - 2026-03-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Profile current phase section for the authenticated `/profile` tab, reusing the bootstrap profile phase snapshot plus aggregate statistics frequency summary to render the read-only phase block without a standalone phase slice.
 - Introduce personal parameters section for the authenticated `/profile` tab, including canonical `user-parameters` read/update flow, editable profile form card, weekly-goal save support, and selective workouts overview refresh when goal, equipment, or level changes regenerate the personal plan.
 - Add profile bottom section for the authenticated `/profile` tab, including logout and delete-profile confirmation actions plus direct links to the bundled legal documents.
+- Sign-up page now redirects users with unverified emails to the verify-email screen: shows a brief non-dismissible feedback dialog, then automatically pushes the verify-email route after 2 seconds, matching the existing sign-in behavior.
 - Profile subscription section for the authenticated `/profile` tab, including active and empty subscription states, catalog entrypoints, profile-local subscription card hydration by `subscriptionId`, cancel-subscription confirmation flow and profile page refresh after cancellation.
 - Profile saved cards section for the authenticated `/profile` tab, including dedicated cards API/repository flow, saved-cards list rendering, add-card dialog with manual card form, default-card command, delete-card confirmation, and local refresh after successful actions.
 - Authenticated subscriptions catalog screen, including dedicated subscriptions route, catalog Cubit, card UI with normalized remote images, and a profile CTA for opening available subscription plans.
@@ -60,7 +61,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Profile frequency statistics now handle weekly payloads without `short_label`, keep dense period charts readable across `week`, `month`, `3 months`, `6 months`, and `year`, and clarify non-daily X-axis scales with short `нед.` / `мес.` labels.
 - Profile statistics dropdown menus now size to their content and render above surrounding UI instead of being clipped by the statistics card or overlapping incorrectly with lower screen sections.
 - Profile history and statistics copy now matches the latest profile mockups more closely, including `Активность` / `Завершено` labels, the separate `Средняя оценка:` summary label, and shortened cross-year period labels like `25-26`.
-- Sign-up unverified-email redirect now correctly closes the feedback dialog before pushing the verify-email route, and cancels the redirect timer when the widget is disposed.
 
 ## [0.3.1] - 2026-03-25
 

--- a/lib/features/auth/presentation/pages/sign_up_page.dart
+++ b/lib/features/auth/presentation/pages/sign_up_page.dart
@@ -1,9 +1,12 @@
+import 'dart:async';
+
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../../core/constants/app_strings.dart';
+import '../../../../core/failures/feature/auth/auth_failure.dart';
 import '../../../../core/router/router_paths.dart';
 import '../../../../uikit/buttons/button_state.dart';
 import '../../../../uikit/buttons/main_button.dart';
@@ -36,12 +39,46 @@ class _SignUpPageState extends State<SignUpPage> {
 
   bool _isAgree = false;
 
+  NavigatorState? _rootNavigator;
+  Timer? _redirectTimer;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _rootNavigator ??= Navigator.of(context, rootNavigator: true);
+  }
+
   @override
   void dispose() {
+    _redirectTimer?.cancel();
     _nameController.dispose();
     _emailController.dispose();
     _passwordController.dispose();
     super.dispose();
+  }
+
+  void _redirectUnverifiedUser({required String dialogMessage}) {
+    if (_redirectTimer != null) return;
+
+    showAppFeedbackDialog<void>(
+      context,
+      title: AppStrings.feedbackErrorTitle,
+      message: dialogMessage,
+      isBarrierDismissible: false,
+    );
+
+    _redirectTimer = Timer(const Duration(seconds: 2), () {
+      _redirectTimer = null;
+      if (!mounted) return;
+      _rootNavigator?.pop();
+      context.push(
+        AppRoutePaths.verifyEmailPath,
+        extra: VerifyEmailRouteArgs(
+          email: _emailController.text.trim(),
+          resendOnOpen: true,
+        ),
+      );
+    });
   }
 
   void _submit() {
@@ -82,11 +119,13 @@ class _SignUpPageState extends State<SignUpPage> {
           },
           failed: (failure) {
             if (failure.message.isNotEmpty) {
-              showAppFeedbackDialog(
-                context,
-                title: AppStrings.feedbackErrorTitle,
-                message: failure.message,
-              );
+              failure is EmailNotVerifiedFailure
+                  ? _redirectUnverifiedUser(dialogMessage: failure.message)
+                  : showAppFeedbackDialog(
+                      context,
+                      title: AppStrings.feedbackErrorTitle,
+                      message: failure.message,
+                    );
             }
           },
         );


### PR DESCRIPTION
## 🚀 Summary

Previously, when a user tried to sign up with an already-registered but unverified email, the app responded with a generic error dialog and left them on the sign-up screen with no way forward. This PR introduces dedicated handling for `EmailNotVerifiedFailure` on the sign-up page, mirroring the behavior already present in the sign-in flow: a non-dismissible feedback dialog appears briefly, then after 2 seconds the app automatically pushes the verify-email route so the user can complete their confirmation without manually navigating there.