### PR TITLE
fix(subscriptions): force uppercase on payment card holder input

### DIFF
--- a/lib/features/subscriptions/presentation/widgets/subscription_payment_dialog.dart
+++ b/lib/features/subscriptions/presentation/widgets/subscription_payment_dialog.dart
@@ -62,6 +62,8 @@ class _SubscriptionPaymentDialogState extends State<SubscriptionPaymentDialog> {
 
   bool _rememberData = false;
 
+  String get _normalizedCardHolder => _cardHolderController.text.trim().toUpperCase();
+
   @override
   void initState() {
     super.initState();
@@ -115,7 +117,7 @@ class _SubscriptionPaymentDialogState extends State<SubscriptionPaymentDialog> {
         subscriptionId: widget.item.id,
         saveCard: _rememberData,
         cardNumber: _cardNumberController.text.replaceAll(RegExp(r'\D'), ''),
-        cardHolder: _cardHolderController.text.trim(),
+        cardHolder: _normalizedCardHolder,
         expiryMonth: _expiryMonthController.text.trim(),
         expiryYear: _buildBackendExpiryYear(expiryYear),
         cvv: _cvvController.text.trim(),
@@ -176,6 +178,7 @@ class _SubscriptionPaymentDialogState extends State<SubscriptionPaymentDialog> {
                       enabled: !isInProgress,
                       keyboardType: TextInputType.name,
                       textInputAction: TextInputAction.next,
+                      inputFormatters: [const _CardHolderTextInputFormatter()],
                       validator: SubscriptionPaymentValidators.cardHolder,
                     ),
                     const SizedBox(height: 12),
@@ -300,7 +303,7 @@ class _SubscriptionPaymentDialogState extends State<SubscriptionPaymentDialog> {
               right: 0,
               child: _PaymentPreviewCard(
                 previewCardNumber: _previewCardNumberController.text,
-                cardHolder: _cardHolderController.text,
+                cardHolder: _normalizedCardHolder,
                 expiryMonth: _expiryMonthController.text.trim(),
                 expiryYear: _expiryYearController.text.trim(),
               ),
@@ -537,6 +540,18 @@ final class _CardNumberTextInputFormatter extends TextInputFormatter {
       text: formatted,
       selection: TextSelection.collapsed(offset: formatted.length),
     );
+  }
+}
+
+final class _CardHolderTextInputFormatter extends TextInputFormatter {
+  const _CardHolderTextInputFormatter();
+
+  @override
+  TextEditingValue formatEditUpdate(
+    TextEditingValue oldValue,
+    TextEditingValue newValue,
+  ) {
+    return newValue.copyWith(text: newValue.text.toUpperCase());
   }
 }
 


### PR DESCRIPTION
## Why
The "add card" dialog in Profile auto-uppercases the cardholder name as you type and stores/displays the normalized value. The subscription payment dialog had no such formatter — lowercase input was accepted on screen but fails the `^[A-Z ]+$` validator on submit, and the preview/payload sent raw (unnormalized) text. Two dialogs with the same field behaved differently.

## What
- Added `_CardHolderTextInputFormatter` to `subscription_payment_dialog.dart` (same formatter as in `save_card_dialog.dart`) — forces uppercase as the user types.
- Added `_normalizedCardHolder` getter (`trim().toUpperCase()`), used for the payment payload and the card preview.

## How to test
1. Profile → Subscriptions catalog → open payment dialog → type a cardholder name in lowercase.
2. Confirm it displays in uppercase as you type (both in the field and in the card preview), matching the "add card" dialog in Profile.
3. Submit with a valid card — payment proceeds without a cardholder validation error.